### PR TITLE
chore: update CHANGELOGs to reflect version bump to 0.1.0-alpha.1 for…

### DIFF
--- a/packages/dartpollo/CHANGELOG.md
+++ b/packages/dartpollo/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0
+## 0.1.0-alpha.1
 
 ### Breaking Changes
 

--- a/packages/dartpollo_annotation/CHANGELOG.md
+++ b/packages/dartpollo_annotation/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0
+## 0.1.0-alpha.1
 
 - Initial release as standalone package
 - Contains shared types: `GraphQLQuery`, `GraphQLResponse`, `GeneratorOptions`, `SchemaMap`, `ScalarMap`, `DartType`, `NamingScheme`

--- a/packages/dartpollo_generator/CHANGELOG.md
+++ b/packages/dartpollo_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0
+## 0.1.0-alpha.1
 
 - Initial release as standalone package
 - Code generator extracted from `dartpollo` monolith


### PR DESCRIPTION
This pull request updates the version numbers for the initial releases of the `dartpollo`, `dartpollo_annotation`, and `dartpollo_generator` packages to use the `0.1.0-alpha.1` pre-release version. This change ensures consistency across the packages and clarifies that these are alpha releases.

Versioning updates:

* Updated the version in `CHANGELOG.md` for `dartpollo`, `dartpollo_annotation`, and `dartpollo_generator` from `0.1.0` to `0.1.0-alpha.1` to indicate alpha pre-release status. [[1]](diffhunk://#diff-5df81543296ba69a0697f4f353753b04093616097b49f9f3172180a3c357808fL1-R1) [[2]](diffhunk://#diff-424f0d07ce79e4414de5c064ec333101503f9f09552e955815e04aa5ff873e8aL1-R1) [[3]](diffhunk://#diff-b71d2300d6d4a639cdd5d98a72f951d6b898986d8614bf9fb14856b720e5ba48L1-R1)… all packages

**Make sure you're opening this pull request pointing to beta branch!**

## What does this PR do/solve?
