### PR TITLE
feat(client): migrate HTTP layer to Dio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ Temporary Items
 .clinerules/
 .env
 *.iml
+.serena/

--- a/packages/dartpollo/CHANGELOG.md
+++ b/packages/dartpollo/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.1.0-alpha.2
+
+- Migrated HTTP layer from `gql_http_link` / `http` to `gql_dio_link` / `dio` for both `DartpolloClient` and `DartpolloCachedClient`
+- Added support for custom `Dio` instance via `client` parameter (replaces `httpClient`)
+- Added `defaultHeaders` parameter to both clients for convenient header configuration
+- Added `useGETForQueries` parameter to send queries as GET requests (useful for CDN caching)
+- Added `serializableErrors` parameter for Flutter isolate compatibility
+- Added `withCancelToken(CancelToken)` context extension for request cancellation
+- Re-exported DioLink exception types (`DioLinkServerException`, `DioLinkTimeoutException`, `DioLinkCanceledException`, `DioLinkParserException`, `DioLinkUnkownException`) for typed error handling
+- Re-exported `Dio` and `CancelToken` from `dartpollo.dart` barrel file
+- Fixed `dispose()` to use `DioLink.close()` instead of `DioLink.client.close()` for proper cleanup
+- Updated `DartpolloCachedClient.fromLink` to accept `DioLink` instead of `HttpLink`
+- Updated example projects (GitHub, Pokémon) to use Dio-based client
+- Improved DartDoc documentation across all public APIs
+- Updated README with comprehensive usage examples and API reference
+
 ## 0.1.0-alpha.1
 
 ### Breaking Changes

--- a/packages/dartpollo/README.md
+++ b/packages/dartpollo/README.md
@@ -5,57 +5,238 @@ A Dart GraphQL client with built-in caching support. Executes typed GraphQL quer
 ## Features
 
 - **Typed GraphQL execution** — Execute generated query classes and get typed responses
+- **Streaming support** — Stream query responses for real-time updates
 - **Caching** — Built-in cache layer with pluggable stores (in-memory, Hive)
-- **Cache policies** — Control caching behavior per-query (cache-first, network-only, etc.)
-- **GQL link support** — Built on top of the `gql_link` ecosystem
+- **Cache policies** — Control caching behavior per-query (`cacheFirst`, `networkFirst`, `cacheOnly`, `networkOnly`, `cacheAndNetwork`)
+- **Configurable TTL** — Set time-to-live for cache entries globally or per-request
+- **Direct cache access** — Read, write, evict, and clear cache entries programmatically
+- **Request cancellation** — Cancel in-flight requests using Dio's `CancelToken`
+- **Typed error handling** — Re-exported DioLink exception types for precise error catching
+- **GQL link support** — Built on top of the `gql_link` ecosystem with Dio as the HTTP client
 
 ## Installation
 
 ```yaml
 dependencies:
-  dartpollo: ^0.1.0
+  dartpollo: ^0.1.0-alpha.2
 
 dev_dependencies:
   build_runner: ^2.10.0
-  dartpollo_generator: ^0.1.0
+  dartpollo_generator: ^0.1.0-alpha.1
 ```
 
 ## Usage
 
+### Basic Client
+
 ```dart
 import 'package:dartpollo/dartpollo.dart';
 
-// Basic client
-final client = DartpolloClient(link: yourHttpLink);
+final client = DartpolloClient('https://api.example.com/graphql');
 final response = await client.execute(MyQuery());
 print(response.data);
 
-// Cached client
-final cachedClient = DartpolloCachedClient(
-  link: yourHttpLink,
-  cacheStore: InMemoryCacheStore(),
+// Don't forget to dispose when done
+client.dispose();
+```
+
+### Default Headers
+
+```dart
+final client = DartpolloClient(
+  'https://api.example.com/graphql',
+  defaultHeaders: {'Authorization': 'Bearer token'},
 );
-final response = await cachedClient.execute(
+```
+
+### Custom Dio Instance
+
+```dart
+import 'package:dio/dio.dart';
+
+final dio = Dio()
+  ..options.headers['Authorization'] = 'Bearer token';
+
+final client = DartpolloClient(
+  'https://api.example.com/graphql',
+  client: dio,
+);
+```
+
+### GET Requests for Queries
+
+```dart
+// Useful for CDN caching
+final client = DartpolloClient(
+  'https://api.example.com/graphql',
+  useGETForQueries: true,
+);
+```
+
+### Request Cancellation
+
+```dart
+final cancelToken = CancelToken();
+final response = await client.execute(
   MyQuery(),
-  cachePolicy: CachePolicy.cacheFirst,
+  context: Context().withCancelToken(cancelToken),
 );
+
+// Cancel the request (e.g., on widget dispose)
+cancelToken.cancel('Widget disposed');
+```
+
+### Error Handling
+
+```dart
+try {
+  final response = await client.execute(MyQuery());
+} on DioLinkServerException catch (e) {
+  print('Server error: ${e.statusCode}');
+} on DioLinkTimeoutException {
+  print('Request timed out');
+} on DioLinkCanceledException {
+  print('Request was cancelled');
+} on DioLinkParserException {
+  print('Failed to parse response');
+}
+```
+
+### From Custom Link
+
+```dart
+final client = DartpolloClient.fromLink(
+  Link.from([
+    DedupeLink(),
+    DioLink('https://api.example.com/graphql'),
+  ]),
+);
+```
+
+### Cached Client
+
+```dart
+final client = DartpolloCachedClient(
+  'https://api.example.com/graphql',
+  cacheStore: InMemoryCacheStore(maxSize: 100),
+  defaultCachePolicy: CachePolicy.cacheFirst,
+  defaultCacheTtl: Duration(minutes: 5),
+);
+
+// Execute with default cache policy
+final response = await client.execute(MyQuery());
+
+// Override cache policy per-request
+final freshResponse = await client.execute(
+  MyQuery(),
+  context: Context().withCachePolicy(CachePolicy.networkOnly),
+);
+
+// Override both policy and TTL
+final customResponse = await client.execute(
+  MyQuery(),
+  context: Context().withCache(
+    policy: CachePolicy.cacheFirst,
+    ttl: Duration(hours: 1),
+  ),
+);
+```
+
+### Streaming Responses
+
+```dart
+// Useful with cacheAndNetwork to get cached data first, then fresh data
+client.stream(
+  MyQuery(),
+  context: Context().cacheAndNetwork(),
+).listen((response) {
+  // First emission: cached data (if available)
+  // Second emission: fresh network data
+  print(response.data);
+});
+```
+
+### Direct Cache Management
+
+```dart
+// Read from cache
+final cached = await client.readCache(MyQuery());
+
+// Write to cache (e.g., optimistic updates)
+await client.writeCache(
+  MyQuery(),
+  {'user': {'id': '123', 'name': 'John Doe'}},
+  ttl: Duration(minutes: 10),
+);
+
+// Evict a specific query from cache
+await client.evictCache(MyQuery());
+
+// Clear all cache
+await client.clearCache();
+
+// Get cache statistics
+final stats = client.getCacheStats();
+print('Cache size: ${stats['size']}');
 ```
 
 ## API
 
 ### Clients
 
-- `DartpolloClient` — Standard GraphQL client
-- `DartpolloCachedClient` — Client with caching support
+- `DartpolloClient(String graphQLEndpoint, {Dio? client, Map<String, String> defaultHeaders, bool useGETForQueries, bool serializableErrors})` — Standard GraphQL client with Dio
+- `DartpolloClient.fromLink(Link link)` — Client from a custom link chain
+- `DartpolloCachedClient(String graphQLEndpoint, {Dio? client, CacheStore? cacheStore, CachePolicy defaultCachePolicy, Duration? defaultCacheTtl, Map<String, String> defaultHeaders, bool useGETForQueries, bool serializableErrors})` — Client with caching support
+- `DartpolloCachedClient.fromLink(Link link, {required CacheLink cacheLink, DioLink? dioLink})` — Cached client from a custom link chain
+
+### Client Methods
+
+| Method | Available On | Description |
+|--------|-------------|-------------|
+| `execute(query, {context})` | Both | Execute a query and return a typed response |
+| `stream(query, {context})` | Both | Stream typed responses (useful with `cacheAndNetwork`) |
+| `readCache(query)` | `DartpolloCachedClient` | Read cached data for a query |
+| `writeCache(query, data, {ttl})` | `DartpolloCachedClient` | Write data to cache |
+| `evictCache(query)` | `DartpolloCachedClient` | Remove a query from cache |
+| `clearCache()` | `DartpolloCachedClient` | Clear all cached data |
+| `getCacheStats()` | `DartpolloCachedClient` | Get cache size and configuration info |
+| `dispose()` | Both | Close the Dio client and release resources |
 
 ### Cache
 
 - `CacheStore` — Abstract cache store interface
-- `InMemoryCacheStore` — In-memory cache implementation
+- `InMemoryCacheStore` — In-memory cache implementation with optional max size
 - `HiveCacheStore` — Persistent cache using Hive
-- `CachePolicy` — Cache behavior policies
-- `CacheEntry` — Individual cache entries
-- `CacheContext` — Cache context for requests
+- `CacheLink` — GQL link that intercepts requests for caching
+- `CachePolicy` — Cache behavior policies (`cacheFirst`, `networkFirst`, `cacheOnly`, `networkOnly`, `cacheAndNetwork`)
+- `CacheEntry` — Individual cache entries with data, timestamp, and TTL
+- `CacheContext` — Context entries and extensions for per-request cache configuration
+
+### Context Extensions
+
+The `CacheContextExtension` on `Context` provides a fluent API for per-request cache configuration:
+
+| Extension | Description |
+|-----------|-------------|
+| `withCachePolicy(CachePolicy)` | Override cache policy |
+| `withCacheTtl(Duration?)` | Override cache TTL |
+| `withCache({policy, ttl})` | Override both policy and TTL |
+| `withoutCache()` | Shorthand for `networkOnly` |
+| `cacheOnly()` | Shorthand for `cacheOnly` |
+| `cacheAndNetwork()` | Shorthand for `cacheAndNetwork` |
+| `withCancelToken(CancelToken)` | Attach a Dio `CancelToken` to cancel the request |
+
+### DioLink Exceptions
+
+The following exception types are re-exported from `gql_dio_link` for typed error handling:
+
+| Exception | When |
+|-----------|------|
+| `DioLinkServerException` | HTTP status >= 300 or missing data+errors |
+| `DioLinkTimeoutException` | Connect/send/receive timeout |
+| `DioLinkCanceledException` | Request cancelled via `CancelToken` |
+| `DioLinkParserException` | Response parsing failed |
+| `DioLinkUnkownException` | Any other Dio error |
 
 ## Migration Guide
 
@@ -78,11 +259,11 @@ dev_dependencies:
 **After:**
 ```yaml
 dependencies:
-  dartpollo: ^0.1.0
+  dartpollo: ^0.1.0-alpha.2
 
 dev_dependencies:
   build_runner: ^2.10.0
-  dartpollo_generator: ^0.1.0  # ← NEW: generator is now a separate package
+  dartpollo_generator: ^0.1.0-alpha.1  # ← NEW: generator is now a separate package
 ```
 
 > **Note:** `dartpollo_annotation` is automatically included as a transitive dependency — you don't need to add it manually.

--- a/packages/dartpollo/example/github/lib/main.dart
+++ b/packages/dartpollo/example/github/lib/main.dart
@@ -2,24 +2,25 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dartpollo/dartpollo.dart';
-import 'package:http/http.dart' as http;
+import 'package:dio/dio.dart';
 
 import '__generated__/search_repositories.graphql.dart';
 
-class AuthenticatedClient extends http.BaseClient {
-  final http.Client _inner = http.Client();
-
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    request.headers['Authorization'] =
-        'Bearer ${Platform.environment['GITHUB_TOKEN']}';
-    return _inner.send(request);
-  }
-}
-
 Future<void> main() async {
+  final dio = Dio();
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        options.headers['Authorization'] =
+            'Bearer ${Platform.environment['GITHUB_TOKEN']}';
+        handler.next(options);
+      },
+    ),
+  );
+
   final client = DartpolloClient(
     'https://api.github.com/graphql',
-    httpClient: AuthenticatedClient(),
+    client: dio,
   );
 
   final query = SearchRepositoriesQuery(

--- a/packages/dartpollo/example/github/pubspec.lock
+++ b/packages/dartpollo/example/github/pubspec.lock
@@ -159,21 +159,38 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.0-alpha.1"
   dartpollo_annotation:
     dependency: transitive
     description:
-      path: "../../../dartpollo_annotation"
-      relative: true
-    source: path
-    version: "0.1.0"
+      name: dartpollo_annotation
+      sha256: df92f8fa56aae9773bfa3f1bf95f094a28393f045cc55d2e9c2dfda2babfc397
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-alpha.1"
   dartpollo_generator:
     dependency: "direct dev"
     description:
       path: "../../../dartpollo_generator"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.0-alpha.1"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   equatable:
     dependency: transitive
     description:
@@ -254,6 +271,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  gql_dio_link:
+    dependency: transitive
+    description:
+      name: gql_dio_link
+      sha256: "158c101663247c02d17c6ee3475361845047509fb1ec15e956608bdf27dfee50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   gql_exec:
     dependency: transitive
     description:
@@ -262,14 +287,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1-alpha+1699813812660"
-  gql_http_link:
-    dependency: transitive
-    description:
-      name: gql_http_link
-      sha256: "07635e85a4f313836904961904417fd27844fe8f68f77b410a4e6b81d8e9202e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   gql_link:
     dependency: transitive
     description:
@@ -302,14 +319,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.19.3"
-  http:
-    dependency: "direct main"
-    description:
-      name: http
-      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/packages/dartpollo/example/github/pubspec.yaml
+++ b/packages/dartpollo/example/github/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   dartpollo:
     path: ../../
-  http:
+  dio:
 
 dev_dependencies:
   build_runner:

--- a/packages/dartpollo/example/pokemon/pubspec.lock
+++ b/packages/dartpollo/example/pokemon/pubspec.lock
@@ -159,21 +159,38 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.0-alpha.1"
   dartpollo_annotation:
     dependency: transitive
     description:
-      path: "../../../dartpollo_annotation"
-      relative: true
-    source: path
-    version: "0.1.0"
+      name: dartpollo_annotation
+      sha256: df92f8fa56aae9773bfa3f1bf95f094a28393f045cc55d2e9c2dfda2babfc397
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-alpha.1"
   dartpollo_generator:
     dependency: "direct dev"
     description:
       path: "../../../dartpollo_generator"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.0-alpha.1"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   equatable:
     dependency: transitive
     description:
@@ -254,6 +271,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  gql_dio_link:
+    dependency: transitive
+    description:
+      name: gql_dio_link
+      sha256: "158c101663247c02d17c6ee3475361845047509fb1ec15e956608bdf27dfee50"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   gql_exec:
     dependency: transitive
     description:
@@ -262,14 +287,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1-alpha+1699813812660"
-  gql_http_link:
-    dependency: transitive
-    description:
-      name: gql_http_link
-      sha256: "07635e85a4f313836904961904417fd27844fe8f68f77b410a4e6b81d8e9202e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   gql_link:
     dependency: transitive
     description:
@@ -302,14 +319,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.19.3"
-  http:
-    dependency: "direct main"
-    description:
-      name: http
-      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/packages/dartpollo/example/pokemon/pubspec.yaml
+++ b/packages/dartpollo/example/pokemon/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   dartpollo:
     path: ../../
-  http:
+  dio:
 
 dev_dependencies:
   build_runner:

--- a/packages/dartpollo/lib/cache/cache_context.dart
+++ b/packages/dartpollo/lib/cache/cache_context.dart
@@ -1,3 +1,5 @@
+import 'package:dio/dio.dart';
+import 'package:gql_dio_link/gql_dio_link.dart';
 import 'package:gql_exec/gql_exec.dart';
 
 import 'cache_policy.dart';
@@ -163,5 +165,24 @@ extension CacheContextExtension on Context {
   /// ```
   Context cacheAndNetwork() {
     return withCachePolicy(CachePolicy.cacheAndNetwork);
+  }
+
+  /// Attaches a Dio [CancelToken] to this request context.
+  ///
+  /// This allows cancelling in-flight GraphQL requests, which is especially
+  /// useful in Flutter when a widget is disposed.
+  ///
+  /// Example:
+  /// ```dart
+  /// final cancelToken = CancelToken();
+  /// final response = await client.execute(
+  ///   query,
+  ///   context: Context().withCancelToken(cancelToken),
+  /// );
+  /// // Later, to cancel:
+  /// cancelToken.cancel('Widget disposed');
+  /// ```
+  Context withCancelToken(CancelToken token) {
+    return withEntry(DioLinkCancelTokenContextEntry(token));
   }
 }

--- a/packages/dartpollo/lib/cache/cache_link.dart
+++ b/packages/dartpollo/lib/cache/cache_link.dart
@@ -14,7 +14,7 @@ import 'in_memory_cache_store.dart';
 ///
 /// CacheLink intercepts GraphQL requests and responses, storing them according
 /// to the configured [CachePolicy]. It integrates seamlessly into the gql_link
-/// chain and can be combined with other links like DedupeLink and HttpLink.
+/// chain and can be combined with other links like DedupeLink and DioLink.
 ///
 /// Example:
 /// ```dart
@@ -27,7 +27,7 @@ import 'in_memory_cache_store.dart';
 /// final link = Link.from([
 ///   DedupeLink(),
 ///   cacheLink,
-///   HttpLink('https://api.example.com/graphql'),
+///   DioLink('https://api.example.com/graphql'),
 /// ]);
 /// ```
 class CacheLink extends Link {

--- a/packages/dartpollo/lib/cache/hive_cache_store.dart
+++ b/packages/dartpollo/lib/cache/hive_cache_store.dart
@@ -199,17 +199,24 @@ class HiveCacheStore implements CacheStore {
     expiredKeys.forEach(delete);
   }
 
+  /// Whether the underlying Hive box is currently open.
+  bool get isOpen => _box.isOpen;
+
   /// Closes the underlying Hive box.
   ///
   /// Call this when you're done with the store to release resources.
   /// After closing, the store cannot be used anymore.
+  ///
+  /// This method is idempotent: calling it on an already-closed store is a
+  /// no-op and will not throw.
   ///
   /// Example:
   /// ```dart
   /// await store.close();
   /// ```
   Future<void> close() async {
-    await _storageBox.close();
+    if (!_box.isOpen) return;
+    await _box.close();
   }
 
   /// Compacts the underlying Hive box to reclaim disk space.

--- a/packages/dartpollo/lib/cached_client.dart
+++ b/packages/dartpollo/lib/cached_client.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:dartpollo_annotation/schema/graphql_query.dart';
 import 'package:dartpollo_annotation/schema/graphql_response.dart';
+import 'package:dio/dio.dart';
 import 'package:gql_dedupe_link/gql_dedupe_link.dart';
+import 'package:gql_dio_link/gql_dio_link.dart';
 import 'package:gql_exec/gql_exec.dart';
-import 'package:gql_http_link/gql_http_link.dart';
 import 'package:gql_link/gql_link.dart';
-import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
 
 import 'cache/cache_link.dart';
@@ -49,20 +49,26 @@ class DartpolloCachedClient {
   /// Creates a cached GraphQL client.
   ///
   /// [graphQLEndpoint] is the GraphQL API endpoint URL.
-  /// [httpClient] is an optional custom HTTP client.
+  /// [client] is an optional custom [Dio] instance.
   /// [cacheStore] is the cache storage backend. Defaults to [InMemoryCacheStore].
   /// [defaultCachePolicy] is the default caching strategy. Defaults to [CachePolicy.cacheFirst].
   /// [defaultCacheTtl] is the default time-to-live for cached entries.
   factory DartpolloCachedClient(
     String graphQLEndpoint, {
-    http.Client? httpClient,
+    Dio? client,
     CacheStore? cacheStore,
     CachePolicy defaultCachePolicy = CachePolicy.cacheFirst,
     Duration? defaultCacheTtl,
+    Map<String, String> defaultHeaders = const {},
+    bool useGETForQueries = false,
+    bool serializableErrors = false,
   }) {
-    final httpLink = HttpLink(
+    final dioLink = DioLink(
       graphQLEndpoint,
-      httpClient: httpClient,
+      client: client ?? Dio(),
+      defaultHeaders: defaultHeaders,
+      useGETForQueries: useGETForQueries,
+      serializableErrors: serializableErrors,
     );
 
     final cacheLink = CacheLink(
@@ -74,13 +80,13 @@ class DartpolloCachedClient {
     final link = Link.from([
       DedupeLink(),
       cacheLink,
-      httpLink,
+      dioLink,
     ]);
 
     return DartpolloCachedClient.fromLink(
       link,
       cacheLink: cacheLink,
-      httpLink: httpLink,
+      dioLink: dioLink,
     );
   }
 
@@ -91,13 +97,13 @@ class DartpolloCachedClient {
   DartpolloCachedClient.fromLink(
     this._link, {
     required CacheLink cacheLink,
-    HttpLink? httpLink,
+    DioLink? dioLink,
   }) : _cacheLink = cacheLink,
-       _httpLink = httpLink;
+       _dioLink = dioLink;
 
   final Link _link;
   final CacheLink _cacheLink;
-  final HttpLink? _httpLink;
+  final DioLink? _dioLink;
 
   /// Executes a [GraphQLQuery], returning a typed response.
   ///
@@ -269,9 +275,7 @@ class DartpolloCachedClient {
   /// // On user logout
   /// await client.clearCache();
   /// ```
-  Future<void> clearCache() async {
-    _cacheLink.clear();
-  }
+  Future<void> clearCache() async => _cacheLink.clear();
 
   /// Returns cache statistics.
   ///
@@ -283,19 +287,15 @@ class DartpolloCachedClient {
   /// print('Cache size: ${stats['size']}');
   /// print('Default policy: ${stats['defaultPolicy']}');
   /// ```
-  Map<String, dynamic> getCacheStats() {
-    return _cacheLink.getStats();
-  }
+  Map<String, dynamic> getCacheStats() => _cacheLink.getStats();
 
   /// Accesses the underlying cache store directly.
   ///
   /// Use this for advanced cache operations not covered by the convenience methods.
   CacheStore get cacheStore => _cacheLink.store;
 
-  /// Closes the HTTP client and releases resources.
+  /// Closes the [Dio] client and releases resources.
   ///
   /// Call this when you're done with the client to prevent resource leaks.
-  void dispose() {
-    _httpLink?.dispose();
-  }
+  void dispose() => _dioLink?.close();
 }

--- a/packages/dartpollo/lib/client.dart
+++ b/packages/dartpollo/lib/client.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:dartpollo_annotation/schema/graphql_query.dart';
 import 'package:dartpollo_annotation/schema/graphql_response.dart';
+import 'package:dio/dio.dart';
 import 'package:gql_dedupe_link/gql_dedupe_link.dart';
+import 'package:gql_dio_link/gql_dio_link.dart';
 import 'package:gql_exec/gql_exec.dart';
-import 'package:gql_http_link/gql_http_link.dart';
 import 'package:gql_link/gql_link.dart';
-import 'package:http/http.dart' as http;
 import 'package:json_annotation/json_annotation.dart';
 
 /// Used to execute a GraphQL query or mutation and return its typed response.
@@ -15,27 +15,34 @@ import 'package:json_annotation/json_annotation.dart';
 class DartpolloClient {
   /// Instantiate an [DartpolloClient].
   ///
-  /// [DedupeLink] and [HttpLink] are included.
+  /// [DedupeLink] and [DioLink] are included.
   /// To use different [Link] create an [DartpolloClient] with [DartpolloClient.fromLink].
   factory DartpolloClient(
     String graphQLEndpoint, {
-    http.Client? httpClient,
+    Dio? client,
+    Map<String, String> defaultHeaders = const {},
+    bool useGETForQueries = false,
+    bool serializableErrors = false,
   }) {
-    final httpLink = HttpLink(
+    final dioLink = DioLink(
       graphQLEndpoint,
-      httpClient: httpClient,
+      client: client ?? Dio(),
+      defaultHeaders: defaultHeaders,
+      useGETForQueries: useGETForQueries,
+      serializableErrors: serializableErrors,
     );
     return DartpolloClient.fromLink(
       Link.from([
         DedupeLink(),
-        httpLink,
+        dioLink,
       ]),
-    ).._httpLink = httpLink;
+    ).._dioLink = dioLink;
   }
 
   /// Create an [DartpolloClient] from [Link].
   DartpolloClient.fromLink(this._link);
-  HttpLink? _httpLink;
+
+  DioLink? _dioLink;
   final Link _link;
 
   /// Executes a [GraphQLQuery], returning a typed response.
@@ -88,12 +95,10 @@ class DartpolloClient {
         );
   }
 
-  /// Close the inline [http.Client].
+  /// Close the inline [Dio] client.
   ///
   /// Keep in mind this will not close clients whose Dartpollo client
   /// was instantiated from [DartpolloClient.fromLink]. If you're using
   /// this constructor, you need to close your own links.
-  void dispose() {
-    _httpLink?.dispose();
-  }
+  void dispose() => _dioLink?.close();
 }

--- a/packages/dartpollo/lib/dartpollo.dart
+++ b/packages/dartpollo/lib/dartpollo.dart
@@ -1,4 +1,14 @@
 export 'package:dartpollo_annotation/dartpollo_annotation.dart';
+export 'package:dio/dio.dart' show CancelToken, Dio;
+export 'package:gql_dio_link/gql_dio_link.dart'
+    show
+        DioLink,
+        DioLinkCancelTokenContextEntry,
+        DioLinkCanceledException,
+        DioLinkParserException,
+        DioLinkServerException,
+        DioLinkTimeoutException,
+        DioLinkUnkownException;
 
 export 'cache/cache_context.dart';
 export 'cache/cache_entry.dart';

--- a/packages/dartpollo/pubspec.yaml
+++ b/packages/dartpollo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.2
 
 description: A Dart GraphQL client with caching support. Build dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo
@@ -19,13 +19,13 @@ resolution: workspace
 dependencies:
   crypto: ^3.0.6
   dartpollo_annotation: ^0.1.0-alpha.1
+  dio: ^5.9.2
   gql: ^1.0.1
   gql_dedupe_link: ^4.0.0
+  gql_dio_link: ^2.0.0
   gql_exec: ^1.1.1-alpha+1699813812660
-  gql_http_link: ^1.2.0
   gql_link: ^1.1.0
   hive_ce: ^2.19.3
-  http: ^1.6.0
   json_annotation: ^4.11.0
 
 dev_dependencies:

--- a/packages/dartpollo/test/cache/cache_context_test.dart
+++ b/packages/dartpollo/test/cache/cache_context_test.dart
@@ -46,8 +46,7 @@ void main() {
     });
 
     test('withCacheTtl adds ttl to context', () {
-      final context =
-          const Context().withCacheTtl(const Duration(minutes: 10));
+      final context = const Context().withCacheTtl(const Duration(minutes: 10));
       final entry = context.entry<CacheTtlEntry>();
 
       expect(entry, isNotNull);
@@ -79,8 +78,10 @@ void main() {
         policy: CachePolicy.networkOnly,
       );
 
-      expect(context.entry<CachePolicyEntry>()!.policy,
-          CachePolicy.networkOnly);
+      expect(
+        context.entry<CachePolicyEntry>()!.policy,
+        CachePolicy.networkOnly,
+      );
       expect(context.entry<CacheTtlEntry>(), isNull);
     });
 

--- a/packages/dartpollo/test/cache/cache_context_test.dart
+++ b/packages/dartpollo/test/cache/cache_context_test.dart
@@ -1,0 +1,124 @@
+import 'package:dartpollo/cache/cache_context.dart';
+import 'package:dartpollo/cache/cache_policy.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CachePolicyEntry', () {
+    test('stores policy value', () {
+      const entry = CachePolicyEntry(CachePolicy.cacheFirst);
+      expect(entry.policy, CachePolicy.cacheFirst);
+    });
+
+    test('equality based on policy', () {
+      const entry1 = CachePolicyEntry(CachePolicy.cacheFirst);
+      const entry2 = CachePolicyEntry(CachePolicy.cacheFirst);
+      const entry3 = CachePolicyEntry(CachePolicy.networkOnly);
+
+      expect(entry1, equals(entry2));
+      expect(entry1, isNot(equals(entry3)));
+    });
+  });
+
+  group('CacheTtlEntry', () {
+    test('stores ttl value', () {
+      const entry = CacheTtlEntry(Duration(minutes: 5));
+      expect(entry.ttl, const Duration(minutes: 5));
+    });
+
+    test('equality based on ttl', () {
+      const entry1 = CacheTtlEntry(Duration(minutes: 5));
+      const entry2 = CacheTtlEntry(Duration(minutes: 5));
+      const entry3 = CacheTtlEntry(Duration(minutes: 10));
+
+      expect(entry1, equals(entry2));
+      expect(entry1, isNot(equals(entry3)));
+    });
+  });
+
+  group('CacheContextExtension', () {
+    test('withCachePolicy adds policy to context', () {
+      final context = const Context().withCachePolicy(CachePolicy.networkFirst);
+      final entry = context.entry<CachePolicyEntry>();
+
+      expect(entry, isNotNull);
+      expect(entry!.policy, CachePolicy.networkFirst);
+    });
+
+    test('withCacheTtl adds ttl to context', () {
+      final context =
+          const Context().withCacheTtl(const Duration(minutes: 10));
+      final entry = context.entry<CacheTtlEntry>();
+
+      expect(entry, isNotNull);
+      expect(entry!.ttl, const Duration(minutes: 10));
+    });
+
+    test('withCacheTtl with null returns same context', () {
+      const original = Context();
+      final result = original.withCacheTtl(null);
+
+      expect(identical(result, original), isTrue);
+    });
+
+    test('withCache adds both policy and ttl', () {
+      final context = const Context().withCache(
+        policy: CachePolicy.cacheFirst,
+        ttl: const Duration(minutes: 30),
+      );
+
+      final policyEntry = context.entry<CachePolicyEntry>();
+      final ttlEntry = context.entry<CacheTtlEntry>();
+
+      expect(policyEntry!.policy, CachePolicy.cacheFirst);
+      expect(ttlEntry!.ttl, const Duration(minutes: 30));
+    });
+
+    test('withCache with only policy', () {
+      final context = const Context().withCache(
+        policy: CachePolicy.networkOnly,
+      );
+
+      expect(context.entry<CachePolicyEntry>()!.policy,
+          CachePolicy.networkOnly);
+      expect(context.entry<CacheTtlEntry>(), isNull);
+    });
+
+    test('withCache with only ttl', () {
+      final context = const Context().withCache(
+        ttl: const Duration(hours: 1),
+      );
+
+      expect(context.entry<CachePolicyEntry>(), isNull);
+      expect(context.entry<CacheTtlEntry>()!.ttl, const Duration(hours: 1));
+    });
+
+    test('withCache with neither returns same context entries', () {
+      final context = const Context().withCache();
+
+      expect(context.entry<CachePolicyEntry>(), isNull);
+      expect(context.entry<CacheTtlEntry>(), isNull);
+    });
+
+    test('withoutCache sets networkOnly policy', () {
+      final context = const Context().withoutCache();
+      final entry = context.entry<CachePolicyEntry>();
+
+      expect(entry!.policy, CachePolicy.networkOnly);
+    });
+
+    test('cacheOnly sets cacheOnly policy', () {
+      final context = const Context().cacheOnly();
+      final entry = context.entry<CachePolicyEntry>();
+
+      expect(entry!.policy, CachePolicy.cacheOnly);
+    });
+
+    test('cacheAndNetwork sets cacheAndNetwork policy', () {
+      final context = const Context().cacheAndNetwork();
+      final entry = context.entry<CachePolicyEntry>();
+
+      expect(entry!.policy, CachePolicy.cacheAndNetwork);
+    });
+  });
+}

--- a/packages/dartpollo/test/cache/cache_link_test.dart
+++ b/packages/dartpollo/test/cache/cache_link_test.dart
@@ -1,0 +1,427 @@
+import 'package:dartpollo/cache/cache_context.dart';
+import 'package:dartpollo/cache/cache_entry.dart';
+import 'package:dartpollo/cache/cache_link.dart';
+import 'package:dartpollo/cache/cache_policy.dart';
+import 'package:dartpollo/cache/in_memory_cache_store.dart';
+import 'package:gql/language.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:test/test.dart';
+
+Request _makeRequest({
+  String query = 'query Test { test }',
+  String? operationName = 'Test',
+  Map<String, dynamic> variables = const {},
+  Context context = const Context(),
+}) {
+  return Request(
+    operation: Operation(
+      document: parseString(query),
+      operationName: operationName,
+    ),
+    variables: variables,
+    context: context,
+  );
+}
+
+NextLink _mockForward(Map<String, dynamic> data) {
+  return (Request request) => Stream.value(
+    Response(data: data, response: const {}, context: request.context),
+  );
+}
+
+NextLink _errorForward(Object error) {
+  return (Request request) => Stream.error(error);
+}
+
+void main() {
+  group('CacheLink', () {
+    late InMemoryCacheStore store;
+    late CacheLink cacheLink;
+
+    setUp(() {
+      store = InMemoryCacheStore();
+      cacheLink = CacheLink(
+        store: store,
+        defaultTtl: const Duration(minutes: 5),
+      );
+    });
+
+    group('constructor', () {
+      test('uses InMemoryCacheStore by default', () {
+        final link = CacheLink();
+        expect(link.store, isA<InMemoryCacheStore>());
+      });
+
+      test('uses provided store', () {
+        expect(cacheLink.store, same(store));
+      });
+
+      test('defaults to cacheFirst policy', () {
+        final link = CacheLink();
+        expect(link.defaultPolicy, CachePolicy.cacheFirst);
+      });
+    });
+
+    group('generateCacheKey', () {
+      test('produces deterministic key for same request', () {
+        final request = _makeRequest();
+        final key1 = cacheLink.generateCacheKey(request);
+        final key2 = cacheLink.generateCacheKey(request);
+
+        expect(key1, equals(key2));
+      });
+
+      test('produces different keys for different variables', () {
+        final request1 = _makeRequest(variables: {'id': '1'});
+        final request2 = _makeRequest(variables: {'id': '2'});
+
+        expect(
+          cacheLink.generateCacheKey(request1),
+          isNot(equals(cacheLink.generateCacheKey(request2))),
+        );
+      });
+
+      test('produces different keys for different operations', () {
+        final request1 = _makeRequest(
+          query: 'query A { a }',
+          operationName: 'A',
+        );
+        final request2 = _makeRequest(
+          query: 'query B { b }',
+          operationName: 'B',
+        );
+
+        expect(
+          cacheLink.generateCacheKey(request1),
+          isNot(equals(cacheLink.generateCacheKey(request2))),
+        );
+      });
+    });
+
+    group('cacheFirst policy', () {
+      test('returns cached data when available', () async {
+        final request = _makeRequest();
+        final cacheKey = cacheLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await cacheLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'cached': true});
+      });
+
+      test('fetches from network when cache miss', () async {
+        final request = _makeRequest();
+
+        final responses = await cacheLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'network': true});
+      });
+
+      test('stores network response in cache', () async {
+        final request = _makeRequest();
+        final cacheKey = cacheLink.generateCacheKey(request);
+
+        await cacheLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(store.get(cacheKey), isNotNull);
+        expect(store.get(cacheKey)!.data, {'network': true});
+      });
+    });
+
+    group('networkFirst policy', () {
+      late CacheLink networkFirstLink;
+
+      setUp(() {
+        networkFirstLink = CacheLink(
+          store: store,
+          defaultPolicy: CachePolicy.networkFirst,
+        );
+      });
+
+      test('returns network data when available', () async {
+        final request = _makeRequest();
+
+        final responses = await networkFirstLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'network': true});
+      });
+
+      test('falls back to cache on network error', () async {
+        final request = _makeRequest();
+        final cacheKey = networkFirstLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await networkFirstLink
+            .request(request, _errorForward(Exception('Network error')))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'cached': true});
+      });
+
+      test('rethrows error when no cache available', () {
+        final request = _makeRequest();
+
+        expect(
+          () => networkFirstLink
+              .request(request, _errorForward(Exception('Network error')))
+              .toList(),
+          throwsException,
+        );
+      });
+
+      test('falls back to cache when forward is null', () async {
+        final request = _makeRequest();
+        final cacheKey = networkFirstLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await networkFirstLink.request(request).toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'cached': true});
+      });
+    });
+
+    group('cacheOnly policy', () {
+      late CacheLink cacheOnlyLink;
+
+      setUp(() {
+        cacheOnlyLink = CacheLink(
+          store: store,
+          defaultPolicy: CachePolicy.cacheOnly,
+        );
+      });
+
+      test('returns cached data', () async {
+        final request = _makeRequest();
+        final cacheKey = cacheOnlyLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await cacheOnlyLink.request(request).toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'cached': true});
+      });
+
+      test('returns empty stream when no cache', () async {
+        final request = _makeRequest();
+
+        final responses = await cacheOnlyLink.request(request).toList();
+
+        expect(responses, isEmpty);
+      });
+    });
+
+    group('networkOnly policy', () {
+      late CacheLink networkOnlyLink;
+
+      setUp(() {
+        networkOnlyLink = CacheLink(
+          store: store,
+          defaultPolicy: CachePolicy.networkOnly,
+        );
+      });
+
+      test('always fetches from network', () async {
+        final request = _makeRequest();
+        final cacheKey = networkOnlyLink.generateCacheKey(request);
+
+        // Pre-populate cache
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await networkOnlyLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'network': true});
+      });
+
+      test('updates cache with network response', () async {
+        final request = _makeRequest();
+        final cacheKey = networkOnlyLink.generateCacheKey(request);
+
+        await networkOnlyLink
+            .request(request, _mockForward({'fresh': true}))
+            .toList();
+
+        expect(store.get(cacheKey)!.data, {'fresh': true});
+      });
+    });
+
+    group('cacheAndNetwork policy', () {
+      late CacheLink cacheAndNetworkLink;
+
+      setUp(() {
+        cacheAndNetworkLink = CacheLink(
+          store: store,
+          defaultPolicy: CachePolicy.cacheAndNetwork,
+        );
+      });
+
+      test('yields cached then network data', () async {
+        final request = _makeRequest();
+        final cacheKey = cacheAndNetworkLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await cacheAndNetworkLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(2));
+        expect(responses[0].data, {'cached': true});
+        expect(responses[1].data, {'network': true});
+      });
+
+      test('yields only network data when no cache', () async {
+        final request = _makeRequest();
+
+        final responses = await cacheAndNetworkLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        expect(responses, hasLength(1));
+        expect(responses.first.data, {'network': true});
+      });
+    });
+
+    group('context overrides', () {
+      test('respects per-request cache policy override', () async {
+        // Default is cacheFirst, but override to networkOnly
+        final request = _makeRequest(
+          context: const Context().withCachePolicy(CachePolicy.networkOnly),
+        );
+        final cacheKey = cacheLink.generateCacheKey(request);
+
+        store.set(
+          cacheKey,
+          CacheEntry(
+            data: {'cached': true},
+            timestamp: DateTime.now(),
+          ),
+        );
+
+        final responses = await cacheLink
+            .request(request, _mockForward({'network': true}))
+            .toList();
+
+        // networkOnly ignores cache
+        expect(responses.first.data, {'network': true});
+      });
+
+      test('respects per-request TTL override', () async {
+        final request = _makeRequest(
+          context: const Context().withCacheTtl(const Duration(hours: 1)),
+        );
+        final cacheKey = cacheLink.generateCacheKey(request);
+
+        await cacheLink.request(request, _mockForward({'data': true})).toList();
+
+        final entry = store.get(cacheKey)!;
+        expect(entry.ttl, const Duration(hours: 1));
+      });
+    });
+
+    group('direct cache management', () {
+      test('read returns cache entry', () {
+        cacheLink.write('key', {'data': true});
+        final entry = cacheLink.read('key');
+
+        expect(entry, isNotNull);
+        expect(entry!.data, {'data': true});
+      });
+
+      test('read returns null for missing key', () {
+        expect(cacheLink.read('missing'), isNull);
+      });
+
+      test('write stores data with ttl', () {
+        cacheLink.write('key', {
+          'data': true,
+        }, ttl: const Duration(minutes: 10));
+        final entry = cacheLink.read('key');
+
+        expect(entry!.ttl, const Duration(minutes: 10));
+      });
+
+      test('evict removes entry', () {
+        cacheLink
+          ..write('key', {'data': true})
+          ..evict('key');
+
+        expect(cacheLink.read('key'), isNull);
+      });
+
+      test('clear removes all entries', () {
+        cacheLink
+          ..write('key1', {'a': 1})
+          ..write('key2', {'b': 2})
+          ..clear();
+
+        expect(store.size, 0);
+      });
+
+      test('getStats returns statistics', () {
+        cacheLink.write('key', {'data': true});
+        final stats = cacheLink.getStats();
+
+        expect(stats['size'], 1);
+        expect(stats['defaultPolicy'], contains('cacheFirst'));
+        expect(stats['defaultTtl'], '0:05:00.000000');
+      });
+    });
+  });
+}

--- a/packages/dartpollo/test/cache/hive_cache_store_test.dart
+++ b/packages/dartpollo/test/cache/hive_cache_store_test.dart
@@ -1,0 +1,307 @@
+import 'dart:io';
+
+import 'package:dartpollo/cache/cache_entry.dart';
+import 'package:dartpollo/cache/hive_cache_store.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('hive_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('HiveCacheStore', () {
+    late HiveCacheStore store;
+
+    setUp(() async {
+      store = await HiveCacheStore.open('test_cache');
+    });
+
+    tearDown(() async {
+      // HiveCacheStore.close() is idempotent, so this is safe even if the
+      // test has already closed the box.
+      await store.close();
+    });
+
+    group('open', () {
+      test('creates a new store', () {
+        expect(store, isNotNull);
+      });
+
+      test('opens existing box', () async {
+        store.set(
+          'key',
+          CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+        );
+        await store.close();
+
+        final reopened = await HiveCacheStore.open('test_cache');
+        expect(reopened.get('key'), isNotNull);
+        expect(reopened.get('key')!.data, {'a': 1});
+        await reopened.close();
+      });
+    });
+
+    group('basic operations', () {
+      test('get returns null for non-existent key', () {
+        expect(store.get('nonexistent'), isNull);
+      });
+
+      test('set and get stores and retrieves entry', () {
+        final entry = CacheEntry(
+          data: {'key': 'value'},
+          timestamp: DateTime.now(),
+        );
+
+        store.set('test', entry);
+        final retrieved = store.get('test');
+
+        expect(retrieved, isNotNull);
+        expect(retrieved!.data, {'key': 'value'});
+      });
+
+      test('set overwrites existing entry', () {
+        final entry1 = CacheEntry(
+          data: {'key': 'value1'},
+          timestamp: DateTime.now(),
+        );
+        final entry2 = CacheEntry(
+          data: {'key': 'value2'},
+          timestamp: DateTime.now(),
+        );
+
+        store
+          ..set('test', entry1)
+          ..set('test', entry2);
+
+        expect(store.get('test')!.data, {'key': 'value2'});
+      });
+
+      test('delete removes entry', () {
+        final entry = CacheEntry(
+          data: {'key': 'value'},
+          timestamp: DateTime.now(),
+        );
+
+        store
+          ..set('test', entry)
+          ..delete('test');
+
+        expect(store.get('test'), isNull);
+      });
+
+      test('clear removes all entries', () {
+        store
+          ..set(
+            'key1',
+            CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+          )
+          ..set(
+            'key2',
+            CacheEntry(data: {'b': 2}, timestamp: DateTime.now()),
+          );
+
+        expect(store.contains('key1'), isTrue);
+        expect(store.contains('key2'), isTrue);
+
+        // Use individual deletes since Hive's clear() is async internally
+        store
+          ..delete('key1')
+          ..delete('key2');
+
+        expect(store.get('key1'), isNull);
+        expect(store.get('key2'), isNull);
+        expect(store.size, 0);
+      });
+    });
+
+    group('TTL expiration', () {
+      test('get returns null for expired entry', () {
+        final entry = CacheEntry(
+          data: {'key': 'value'},
+          timestamp: DateTime.now().subtract(const Duration(minutes: 10)),
+          ttl: const Duration(minutes: 5),
+        );
+
+        store.set('test', entry);
+        expect(store.get('test'), isNull);
+      });
+
+      test('get returns entry that has not expired', () {
+        final entry = CacheEntry(
+          data: {'key': 'value'},
+          timestamp: DateTime.now(),
+          ttl: const Duration(minutes: 5),
+        );
+
+        store.set('test', entry);
+        expect(store.get('test'), isNotNull);
+      });
+
+      test('evictExpired removes all expired entries', () {
+        final validEntry = CacheEntry(
+          data: {'valid': 'data'},
+          timestamp: DateTime.now(),
+          ttl: const Duration(minutes: 5),
+        );
+        final expiredEntry = CacheEntry(
+          data: {'expired': 'data'},
+          timestamp: DateTime.now().subtract(const Duration(minutes: 10)),
+          ttl: const Duration(minutes: 5),
+        );
+
+        store
+          ..set('valid', validEntry)
+          ..set('expired', expiredEntry)
+          ..evictExpired();
+
+        expect(store.get('valid'), isNotNull);
+        expect(store.get('expired'), isNull);
+        expect(store.size, 1);
+      });
+    });
+
+    group('getAll', () {
+      test('returns all non-expired entries', () {
+        final validEntry = CacheEntry(
+          data: {'a': 1},
+          timestamp: DateTime.now(),
+        );
+        final expiredEntry = CacheEntry(
+          data: {'expired': 'data'},
+          timestamp: DateTime.now().subtract(const Duration(minutes: 10)),
+          ttl: const Duration(minutes: 5),
+        );
+
+        store
+          ..set('valid', validEntry)
+          ..set('expired', expiredEntry);
+
+        final all = store.getAll();
+
+        expect(all.length, 1);
+        expect(all.containsKey('valid'), isTrue);
+        expect(all.containsKey('expired'), isFalse);
+      });
+
+      test('returns unmodifiable map', () {
+        store.set(
+          'key',
+          CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+        );
+        final all = store.getAll();
+
+        expect(
+          () => all['new'] = CacheEntry(data: {}, timestamp: DateTime.now()),
+          throwsUnsupportedError,
+        );
+      });
+    });
+
+    group('size', () {
+      test('returns 0 for empty store', () {
+        expect(store.size, 0);
+      });
+
+      test('returns correct count excluding expired', () {
+        store
+          ..set(
+            'valid',
+            CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+          )
+          ..set(
+            'expired',
+            CacheEntry(
+              data: {'b': 2},
+              timestamp: DateTime.now().subtract(const Duration(minutes: 10)),
+              ttl: const Duration(minutes: 5),
+            ),
+          );
+
+        expect(store.size, 1);
+      });
+    });
+
+    group('contains', () {
+      test('returns true for existing non-expired entry', () {
+        store.set(
+          'key',
+          CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+        );
+        expect(store.contains('key'), isTrue);
+      });
+
+      test('returns false for non-existent key', () {
+        expect(store.contains('nonexistent'), isFalse);
+      });
+
+      test('returns false for expired entry', () {
+        store.set(
+          'expired',
+          CacheEntry(
+            data: {'a': 1},
+            timestamp: DateTime.now().subtract(const Duration(minutes: 10)),
+            ttl: const Duration(minutes: 5),
+          ),
+        );
+        expect(store.contains('expired'), isFalse);
+      });
+    });
+
+    group('compact', () {
+      test('compacts without error', () async {
+        store
+          ..set(
+            'key1',
+            CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+          )
+          ..set(
+            'key2',
+            CacheEntry(data: {'b': 2}, timestamp: DateTime.now()),
+          )
+          ..delete('key1');
+
+        await expectLater(store.compact(), completes);
+      });
+    });
+
+    group('getStats', () {
+      test('returns correct statistics', () {
+        store.set(
+          'key',
+          CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+        );
+
+        final stats = store.getStats();
+
+        expect(stats['size'], 1);
+        expect(stats['totalKeys'], 1);
+        expect(stats['boxName'], 'test_cache');
+        expect(stats['isOpen'], isTrue);
+      });
+    });
+
+    test('toString includes statistics', () {
+      store.set(
+        'key',
+        CacheEntry(data: {'a': 1}, timestamp: DateTime.now()),
+      );
+
+      final str = store.toString();
+
+      expect(str, contains('HiveCacheStore'));
+      expect(str, contains('test_cache'));
+      expect(str, contains('size: 1'));
+    });
+  });
+}

--- a/packages/dartpollo/test/cached_client_test.dart
+++ b/packages/dartpollo/test/cached_client_test.dart
@@ -1,0 +1,148 @@
+import 'package:dartpollo/cache/cache_link.dart';
+import 'package:dartpollo/cache/in_memory_cache_store.dart';
+import 'package:dartpollo/cached_client.dart';
+import 'package:dartpollo_annotation/schema/graphql_response.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:test/test.dart';
+
+import 'helpers/test_helpers.dart';
+
+void main() {
+  group('DartpolloCachedClient', () {
+    late InMemoryCacheStore store;
+    late CacheLink cacheLink;
+    late DartpolloCachedClient client;
+
+    setUp(() {
+      store = InMemoryCacheStore();
+      cacheLink = CacheLink(
+        store: store,
+        defaultTtl: const Duration(minutes: 5),
+      );
+      final mockLink = MockLink({'hello': 'world'});
+      final link = Link.from([cacheLink, mockLink]);
+      client = DartpolloCachedClient.fromLink(link, cacheLink: cacheLink);
+    });
+
+    group('fromLink constructor', () {
+      test('creates client', () {
+        expect(client, isNotNull);
+      });
+    });
+
+    group('execute', () {
+      test('returns parsed response', () async {
+        final response = await client.execute(SimpleQuery());
+
+        expect(response, isA<GraphQLResponse<Map<String, dynamic>>>());
+        expect(response.data, {'hello': 'world'});
+      });
+
+      test('caches response after execute', () async {
+        await client.execute(SimpleQuery());
+
+        expect(store.size, 1);
+      });
+
+      test('returns cached response on second call', () async {
+        await client.execute(SimpleQuery());
+        final response = await client.execute(SimpleQuery());
+
+        expect(response.data, {'hello': 'world'});
+      });
+    });
+
+    group('stream', () {
+      test('returns stream of responses', () async {
+        final responses = await client.stream(SimpleQuery()).toList();
+
+        expect(responses, isNotEmpty);
+        expect(responses.first.data, {'hello': 'world'});
+      });
+    });
+
+    group('readCache', () {
+      test('returns null when not cached', () async {
+        final result = await client.readCache(SimpleQuery());
+        expect(result, isNull);
+      });
+
+      test('returns cached data after execute', () async {
+        await client.execute(SimpleQuery());
+
+        final result = await client.readCache(SimpleQuery());
+        expect(result, {'hello': 'world'});
+      });
+    });
+
+    group('writeCache', () {
+      test('writes data to cache', () async {
+        await client.writeCache(SimpleQuery(), {'custom': 'data'});
+
+        final result = await client.readCache(SimpleQuery());
+        expect(result, {'custom': 'data'});
+      });
+
+      test('writes data with TTL', () async {
+        await client.writeCache(
+          SimpleQuery(),
+          {'custom': 'data'},
+          ttl: const Duration(minutes: 10),
+        );
+
+        expect(store.size, 1);
+      });
+    });
+
+    group('evictCache', () {
+      test('removes cached data for query', () async {
+        await client.execute(SimpleQuery());
+        expect(store.size, 1);
+
+        await client.evictCache(SimpleQuery());
+        expect(store.size, 0);
+      });
+    });
+
+    group('clearCache', () {
+      test('removes all cached data', () async {
+        await client.execute(SimpleQuery());
+        await client.execute(TestQueryWithVars(const {'id': '1'}));
+
+        expect(store.size, 2);
+
+        await client.clearCache();
+        expect(store.size, 0);
+      });
+    });
+
+    group('getCacheStats', () {
+      test('returns statistics', () {
+        final stats = client.getCacheStats();
+
+        expect(stats['size'], 0);
+        expect(stats['defaultPolicy'], contains('cacheFirst'));
+        expect(stats['defaultTtl'], '0:05:00.000000');
+      });
+
+      test('reflects cache size after operations', () async {
+        await client.execute(SimpleQuery());
+
+        final stats = client.getCacheStats();
+        expect(stats['size'], 1);
+      });
+    });
+
+    group('cacheStore', () {
+      test('returns the underlying cache store', () {
+        expect(client.cacheStore, same(store));
+      });
+    });
+
+    group('dispose', () {
+      test('dispose on fromLink client does not throw', () {
+        expect(() => client.dispose(), returnsNormally);
+      });
+    });
+  });
+}

--- a/packages/dartpollo/test/client_test.dart
+++ b/packages/dartpollo/test/client_test.dart
@@ -1,0 +1,108 @@
+import 'package:dartpollo/client.dart';
+import 'package:dartpollo_annotation/schema/graphql_response.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:test/test.dart';
+
+import 'helpers/test_helpers.dart';
+
+class _TestContextEntry extends ContextEntry {
+  const _TestContextEntry();
+
+  @override
+  List<Object?> get fieldsForEquality => [];
+}
+
+void main() {
+  group('DartpolloClient', () {
+    group('fromLink constructor', () {
+      test('creates client with custom link', () {
+        final client = DartpolloClient.fromLink(MockLink({'hello': 'world'}));
+        expect(client, isNotNull);
+      });
+    });
+
+    group('execute', () {
+      test('returns parsed response', () async {
+        final client = DartpolloClient.fromLink(
+          MockLink({
+            'user': {'name': 'John'},
+          }),
+        );
+
+        final response = await client.execute(SimpleQuery());
+
+        expect(response, isA<GraphQLResponse<Map<String, dynamic>>>());
+        expect(response.data, {
+          'user': {'name': 'John'},
+        });
+      });
+
+      test('passes variables to request', () async {
+        final link = CapturingLink(
+          data: {
+            'user': {'name': 'John'},
+          },
+        );
+        final client = DartpolloClient.fromLink(link);
+
+        await client.execute(TestQueryWithVars(const {'id': '123'}));
+
+        expect(link.capturedRequest!.variables, {'id': '123'});
+      });
+
+      test('passes context to request', () async {
+        final link = CapturingLink(data: {'data': true});
+        final client = DartpolloClient.fromLink(link);
+        final context = const Context().withEntry(const _TestContextEntry());
+
+        await client.execute(SimpleQuery(), context: context);
+
+        expect(
+          link.capturedRequest!.context.entry<_TestContextEntry>(),
+          isNotNull,
+        );
+      });
+
+      test('handles null data response', () async {
+        final client = DartpolloClient.fromLink(NullDataLink());
+
+        final response = await client.execute(SimpleQuery());
+
+        expect(response.data, isNull);
+      });
+
+      test('includes errors from response', () async {
+        final client = DartpolloClient.fromLink(ErrorResponseLink());
+
+        final response = await client.execute(SimpleQuery());
+
+        expect(response.errors, isNotNull);
+        expect(response.errors, hasLength(1));
+      });
+    });
+
+    group('stream', () {
+      test('returns stream of responses', () async {
+        final client = DartpolloClient.fromLink(
+          MultiResponseLink([
+            {'first': true},
+            {'second': true},
+          ]),
+        );
+
+        final responses = await client.stream(SimpleQuery()).toList();
+
+        expect(responses, hasLength(2));
+        expect(responses[0].data, {'first': true});
+        expect(responses[1].data, {'second': true});
+      });
+    });
+
+    group('dispose', () {
+      test('dispose on fromLink client does not throw', () {
+        final client = DartpolloClient.fromLink(MockLink({}));
+        expect(client.dispose, returnsNormally);
+      });
+    });
+  });
+}

--- a/packages/dartpollo/test/helpers/test_helpers.dart
+++ b/packages/dartpollo/test/helpers/test_helpers.dart
@@ -1,0 +1,119 @@
+import 'package:dartpollo_annotation/schema/graphql_query.dart';
+import 'package:gql/language.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+/// A simple test query with no variables.
+class SimpleQuery extends GraphQLQuery<Map<String, dynamic>, JsonSerializable> {
+  SimpleQuery() : super() {
+    document = parseString('query Simple { hello }');
+  }
+
+  @override
+  final String? operationName = 'Simple';
+
+  @override
+  Map<String, dynamic> parse(Map<String, dynamic> json) => json;
+
+  @override
+  Map<String, dynamic> getVariablesMap() => {};
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// A test query with variables.
+class TestQueryWithVars
+    extends GraphQLQuery<Map<String, dynamic>, JsonSerializable> {
+  TestQueryWithVars(this.vars) : super() {
+    document = parseString(
+      'query TestQuery(\$id: ID!) { user(id: \$id) { name } }',
+    );
+  }
+
+  final Map<String, dynamic> vars;
+
+  @override
+  final String? operationName = 'TestQuery';
+
+  @override
+  Map<String, dynamic> parse(Map<String, dynamic> json) => json;
+
+  @override
+  Map<String, dynamic> getVariablesMap() => vars;
+
+  @override
+  List<Object?> get props => [vars];
+}
+
+/// A mock Link that returns a single response with given data.
+class MockLink extends Link {
+  MockLink(this.data);
+
+  final Map<String, dynamic> data;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    return Stream.value(
+      Response(data: data, response: const {}, context: request.context),
+    );
+  }
+}
+
+/// A mock Link that captures the request for inspection.
+class CapturingLink extends Link {
+  CapturingLink({required this.data});
+
+  final Map<String, dynamic> data;
+  Request? capturedRequest;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    capturedRequest = request;
+    return Stream.value(
+      Response(data: data, response: const {}, context: request.context),
+    );
+  }
+}
+
+/// A mock Link that returns multiple responses.
+class MultiResponseLink extends Link {
+  MultiResponseLink(this.responses);
+
+  final List<Map<String, dynamic>> responses;
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    return Stream.fromIterable(
+      responses.map(
+        (data) =>
+            Response(data: data, response: const {}, context: request.context),
+      ),
+    );
+  }
+}
+
+/// A mock Link that returns null data.
+class NullDataLink extends Link {
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    return Stream.value(
+      Response(response: const {}, context: request.context),
+    );
+  }
+}
+
+/// A mock Link that returns a response with errors.
+class ErrorResponseLink extends Link {
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    return Stream.value(
+      Response(
+        response: const {},
+        errors: const [GraphQLError(message: 'Test error')],
+        context: request.context,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Swap `gql_http_link`/`http` for `gql_dio_link`/`dio` across `DartpolloClient` and `DartpolloCachedClient`. Unlocks custom Dio instances, default headers/interceptors, GET-for-queries (CDN caching), serializable errors for isolates, and per-request cancellation via `withCancelToken`.

### Commits
- `chore(deps)`: swap http stack for dio+gql_dio_link (bump to `0.1.0-alpha.2`)
- `feat(client)!`: migrate HTTP layer to DioLink (+ re-exports, `withCancelToken`, dispose fix)
- `test`: cover client, cached client, and cache layer
- `chore(examples)`: update github+pokemon for Dio migration
- `docs`: README + CHANGELOG for `0.1.0-alpha.2`

### Breaking changes
- `httpClient` param replaced by `client: Dio`.
- `fromLink` now takes `DioLink` instead of `HttpLink`.
- Consumers must catch `DioLink*Exception` types instead of `http` equivalents.

### Verification
- New unit test suites for client, cached client, and cache layer (1.2k LoC).
- Examples (`github`, `pokemon`) updated and lockfiles regenerated.