### PR TITLE
Freezed-style generator headers + workspace deps cleanup

### DIFF
--- a/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.dart
+++ b/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.dart
@@ -1,238 +1,88 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'search_repositories.graphql.g.dart';@JsonSerializable(explicitToJson: true) class SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository extends SearchRepositories$Query$SearchResultItemConnection$SearchResultItem with EquatableMixin {SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository();
 
-part 'search_repositories.graphql.g.dart';
+factory SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository.fromJson(Map<String, dynamic> json) => _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$RepositoryFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository
-    extends SearchRepositories$Query$SearchResultItemConnection$SearchResultItem
-    with EquatableMixin {
-  SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository();
+late String name;
 
-  factory SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository.fromJson(
-    Map<String, dynamic> json,
-  ) =>
-      _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$RepositoryFromJson(
-        json,
-      );
+@override List<Object?> get props => [name];
 
-  late String name;
+@override Map<String, dynamic> toJson() => _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$RepositoryToJson(this);
 
-  @override
-  List<Object?> get props => [name];
+ }
+@JsonSerializable(explicitToJson: true) class SearchRepositories$Query$SearchResultItemConnection$SearchResultItem extends JsonSerializable with EquatableMixin {SearchRepositories$Query$SearchResultItemConnection$SearchResultItem();
 
-  @override
-  Map<String, dynamic> toJson() =>
-      _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$RepositoryToJson(
-        this,
-      );
-}
-
-@JsonSerializable(explicitToJson: true)
-class SearchRepositories$Query$SearchResultItemConnection$SearchResultItem
-    extends JsonSerializable
-    with EquatableMixin {
-  SearchRepositories$Query$SearchResultItemConnection$SearchResultItem();
-
-  factory SearchRepositories$Query$SearchResultItemConnection$SearchResultItem.fromJson(
-    Map<String, dynamic> json,
-  ) {
-    switch (json['__typename'].toString()) {
+factory SearchRepositories$Query$SearchResultItemConnection$SearchResultItem.fromJson(Map<String, dynamic> json) { switch (json['__typename'].toString()) {
       case r'Repository':
-        return SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository.fromJson(
-          json,
-        );
+        return SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository.fromJson(json);
       default:
     }
-    return _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemFromJson(
-      json,
-    );
-  }
+    return _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemFromJson(json);
+ }
 
-  @JsonKey(name: '__typename')
-  String? $$typename;
+@JsonKey(name: '__typename') String? $$typename;
 
-  @override
-  List<Object?> get props => [$$typename];
+@override List<Object?> get props => [$$typename];
 
-  @override
-  Map<String, dynamic> toJson() {
-    switch ($$typename) {
+@override Map<String, dynamic> toJson() { switch ($$typename) {
       case r'Repository':
-        return (this
-                as SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository)
-            .toJson();
+        return (this as SearchRepositories$Query$SearchResultItemConnection$SearchResultItem$Repository).toJson();
       default:
     }
-    return _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemToJson(
-      this,
-    );
-  }
-}
+    return _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemToJson(this);
+ } 
+ }
+@JsonSerializable(explicitToJson: true) class SearchRepositories$Query$SearchResultItemConnection extends JsonSerializable with EquatableMixin {SearchRepositories$Query$SearchResultItemConnection();
 
-@JsonSerializable(explicitToJson: true)
-class SearchRepositories$Query$SearchResultItemConnection
-    extends JsonSerializable
-    with EquatableMixin {
-  SearchRepositories$Query$SearchResultItemConnection();
+factory SearchRepositories$Query$SearchResultItemConnection.fromJson(Map<String, dynamic> json) => _$SearchRepositories$Query$SearchResultItemConnectionFromJson(json);
 
-  factory SearchRepositories$Query$SearchResultItemConnection.fromJson(
-    Map<String, dynamic> json,
-  ) => _$SearchRepositories$Query$SearchResultItemConnectionFromJson(json);
+List<SearchRepositories$Query$SearchResultItemConnection$SearchResultItem?>? nodes;
 
-  List<SearchRepositories$Query$SearchResultItemConnection$SearchResultItem?>?
-  nodes;
+@override List<Object?> get props => [nodes];
 
-  @override
-  List<Object?> get props => [nodes];
+@override Map<String, dynamic> toJson() => _$SearchRepositories$Query$SearchResultItemConnectionToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() =>
-      _$SearchRepositories$Query$SearchResultItemConnectionToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class SearchRepositories$Query extends JsonSerializable with EquatableMixin {SearchRepositories$Query();
 
-@JsonSerializable(explicitToJson: true)
-class SearchRepositories$Query extends JsonSerializable with EquatableMixin {
-  SearchRepositories$Query();
+factory SearchRepositories$Query.fromJson(Map<String, dynamic> json) => _$SearchRepositories$QueryFromJson(json);
 
-  factory SearchRepositories$Query.fromJson(Map<String, dynamic> json) =>
-      _$SearchRepositories$QueryFromJson(json);
+late SearchRepositories$Query$SearchResultItemConnection search;
 
-  late SearchRepositories$Query$SearchResultItemConnection search;
+@override List<Object?> get props => [search];
 
-  @override
-  List<Object?> get props => [search];
+@override Map<String, dynamic> toJson() => _$SearchRepositories$QueryToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$SearchRepositories$QueryToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class SearchRepositoriesArguments extends JsonSerializable with EquatableMixin {SearchRepositoriesArguments({required this.query});
 
-@JsonSerializable(explicitToJson: true)
-class SearchRepositoriesArguments extends JsonSerializable with EquatableMixin {
-  SearchRepositoriesArguments({required this.query});
+@override factory SearchRepositoriesArguments.fromJson(Map<String, dynamic> json) => _$SearchRepositoriesArgumentsFromJson(json);
 
-  @override
-  factory SearchRepositoriesArguments.fromJson(Map<String, dynamic> json) =>
-      _$SearchRepositoriesArgumentsFromJson(json);
+late String query;
 
-  late String query;
+@override List<Object?> get props => [query];
 
-  @override
-  List<Object?> get props => [query];
+@override Map<String, dynamic> toJson() => _$SearchRepositoriesArgumentsToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$SearchRepositoriesArgumentsToJson(this);
-}
-
+ }
 final SEARCH_REPOSITORIES_QUERY_DOCUMENT_OPERATION_NAME = 'search_repositories';
-final SEARCH_REPOSITORIES_QUERY_DOCUMENT = DocumentNode(
-  definitions: [
-    OperationDefinitionNode(
-      type: OperationType.query,
-      name: NameNode(value: 'search_repositories'),
-      variableDefinitions: [
-        VariableDefinitionNode(
-          variable: VariableNode(name: NameNode(value: 'query')),
-          type: NamedTypeNode(
-            name: NameNode(value: 'String'),
-            isNonNull: true,
-          ),
-          defaultValue: DefaultValueNode(value: null),
-          directives: [],
-        ),
-      ],
-      directives: [],
-      selectionSet: SelectionSetNode(
-        selections: [
-          FieldNode(
-            name: NameNode(value: 'search'),
-            alias: null,
-            arguments: [
-              ArgumentNode(
-                name: NameNode(value: 'first'),
-                value: IntValueNode(value: '10'),
-              ),
-              ArgumentNode(
-                name: NameNode(value: 'type'),
-                value: EnumValueNode(name: NameNode(value: 'REPOSITORY')),
-              ),
-              ArgumentNode(
-                name: NameNode(value: 'query'),
-                value: VariableNode(name: NameNode(value: 'query')),
-              ),
-            ],
-            directives: [],
-            selectionSet: SelectionSetNode(
-              selections: [
-                FieldNode(
-                  name: NameNode(value: 'nodes'),
-                  alias: null,
-                  arguments: [],
-                  directives: [],
-                  selectionSet: SelectionSetNode(
-                    selections: [
-                      FieldNode(
-                        name: NameNode(value: '__typename'),
-                        alias: null,
-                        arguments: [],
-                        directives: [],
-                        selectionSet: null,
-                      ),
-                      InlineFragmentNode(
-                        typeCondition: TypeConditionNode(
-                          on: NamedTypeNode(
-                            name: NameNode(value: 'Repository'),
-                            isNonNull: false,
-                          ),
-                        ),
-                        directives: [],
-                        selectionSet: SelectionSetNode(
-                          selections: [
-                            FieldNode(
-                              name: NameNode(value: 'name'),
-                              alias: null,
-                              arguments: [],
-                              directives: [],
-                              selectionSet: null,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  ],
-);
+final SEARCH_REPOSITORIES_QUERY_DOCUMENT = 
+DocumentNode(definitions: [OperationDefinitionNode(type: OperationType.query, name: NameNode(value: 'search_repositories'), variableDefinitions: [VariableDefinitionNode(variable: VariableNode(name: NameNode(value: 'query')), type: NamedTypeNode(name: NameNode(value: 'String'), isNonNull: true, ), defaultValue: DefaultValueNode(value: null), directives: [], )], directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: 'search'), alias: null, arguments: [ArgumentNode(name: NameNode(value: 'first'), value: IntValueNode(value: '10'), ), ArgumentNode(name: NameNode(value: 'type'), value: EnumValueNode(name: NameNode(value: 'REPOSITORY')), ), ArgumentNode(name: NameNode(value: 'query'), value: VariableNode(name: NameNode(value: 'query')), ), ], directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: 'nodes'), alias: null, arguments: [], directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: '__typename'), alias: null, arguments: [], directives: [], selectionSet: null, ), InlineFragmentNode(typeCondition: TypeConditionNode(on: NamedTypeNode(name: NameNode(value: 'Repository'), isNonNull: false, )), directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: 'name'), alias: null, arguments: [], directives: [], selectionSet: null, )]), ), ]), )]), )]), )])
+;class SearchRepositoriesQuery extends GraphQLQuery<SearchRepositories$Query, SearchRepositoriesArguments> {SearchRepositoriesQuery({required this.variables});
 
-class SearchRepositoriesQuery
-    extends
-        GraphQLQuery<SearchRepositories$Query, SearchRepositoriesArguments> {
-  SearchRepositoriesQuery({required this.variables});
+@override final DocumentNode document = SEARCH_REPOSITORIES_QUERY_DOCUMENT;
 
-  @override
-  final DocumentNode document = SEARCH_REPOSITORIES_QUERY_DOCUMENT;
+@override final String operationName = SEARCH_REPOSITORIES_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  final String operationName =
-      SEARCH_REPOSITORIES_QUERY_DOCUMENT_OPERATION_NAME;
+@override final SearchRepositoriesArguments variables;
 
-  @override
-  final SearchRepositoriesArguments variables;
+@override List<Object?> get props => [document, operationName, variables];
 
-  @override
-  List<Object?> get props => [document, operationName, variables];
+@override SearchRepositories$Query parse(Map<String, dynamic> json) => SearchRepositories$Query.fromJson(json);
 
-  @override
-  SearchRepositories$Query parse(Map<String, dynamic> json) =>
-      SearchRepositories$Query.fromJson(json);
-}
+ }

--- a/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.g.dart
+++ b/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.g.dart
@@ -33,9 +33,7 @@ _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemFromJson(
 Map<String, dynamic>
 _$SearchRepositories$Query$SearchResultItemConnection$SearchResultItemToJson(
   SearchRepositories$Query$SearchResultItemConnection$SearchResultItem instance,
-) => <String, dynamic>{
-  '__typename': instance.$$typename,
-};
+) => <String, dynamic>{'__typename': instance.$$typename};
 
 SearchRepositories$Query$SearchResultItemConnection
 _$SearchRepositories$Query$SearchResultItemConnectionFromJson(
@@ -60,26 +58,19 @@ _$SearchRepositories$Query$SearchResultItemConnectionToJson(
 
 SearchRepositories$Query _$SearchRepositories$QueryFromJson(
   Map<String, dynamic> json,
-) =>
-    SearchRepositories$Query()
-      ..search = SearchRepositories$Query$SearchResultItemConnection.fromJson(
-        json['search'] as Map<String, dynamic>,
-      );
+) => SearchRepositories$Query()
+  ..search = SearchRepositories$Query$SearchResultItemConnection.fromJson(
+    json['search'] as Map<String, dynamic>,
+  );
 
 Map<String, dynamic> _$SearchRepositories$QueryToJson(
   SearchRepositories$Query instance,
-) => <String, dynamic>{
-  'search': instance.search.toJson(),
-};
+) => <String, dynamic>{'search': instance.search.toJson()};
 
 SearchRepositoriesArguments _$SearchRepositoriesArgumentsFromJson(
   Map<String, dynamic> json,
-) => SearchRepositoriesArguments(
-  query: json['query'] as String,
-);
+) => SearchRepositoriesArguments(query: json['query'] as String);
 
 Map<String, dynamic> _$SearchRepositoriesArgumentsToJson(
   SearchRepositoriesArguments instance,
-) => <String, dynamic>{
-  'query': instance.query,
-};
+) => <String, dynamic>{'query': instance.query};

--- a/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.g.dart
+++ b/packages/dartpollo/example/github/lib/__generated__/search_repositories.graphql.g.dart
@@ -58,10 +58,11 @@ _$SearchRepositories$Query$SearchResultItemConnectionToJson(
 
 SearchRepositories$Query _$SearchRepositories$QueryFromJson(
   Map<String, dynamic> json,
-) => SearchRepositories$Query()
-  ..search = SearchRepositories$Query$SearchResultItemConnection.fromJson(
-    json['search'] as Map<String, dynamic>,
-  );
+) =>
+    SearchRepositories$Query()
+      ..search = SearchRepositories$Query$SearchResultItemConnection.fromJson(
+        json['search'] as Map<String, dynamic>,
+      );
 
 Map<String, dynamic> _$SearchRepositories$QueryToJson(
   SearchRepositories$Query instance,

--- a/packages/dartpollo/example/github/lib/__generated__/viewer.graphql.dart
+++ b/packages/dartpollo/example/github/lib/__generated__/viewer.graphql.dart
@@ -1,89 +1,42 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'viewer.graphql.g.dart';@JsonSerializable(explicitToJson: true) class Viewer$Query$User extends JsonSerializable with EquatableMixin {Viewer$Query$User();
 
-part 'viewer.graphql.g.dart';
+factory Viewer$Query$User.fromJson(Map<String, dynamic> json) => _$Viewer$Query$UserFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class Viewer$Query$User extends JsonSerializable with EquatableMixin {
-  Viewer$Query$User();
+late String login;
 
-  factory Viewer$Query$User.fromJson(Map<String, dynamic> json) =>
-      _$Viewer$Query$UserFromJson(json);
+@override List<Object?> get props => [login];
 
-  late String login;
+@override Map<String, dynamic> toJson() => _$Viewer$Query$UserToJson(this);
 
-  @override
-  List<Object?> get props => [login];
+ }
+@JsonSerializable(explicitToJson: true) class Viewer$Query extends JsonSerializable with EquatableMixin {Viewer$Query();
 
-  @override
-  Map<String, dynamic> toJson() => _$Viewer$Query$UserToJson(this);
-}
+factory Viewer$Query.fromJson(Map<String, dynamic> json) => _$Viewer$QueryFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class Viewer$Query extends JsonSerializable with EquatableMixin {
-  Viewer$Query();
+late Viewer$Query$User viewer;
 
-  factory Viewer$Query.fromJson(Map<String, dynamic> json) =>
-      _$Viewer$QueryFromJson(json);
+@override List<Object?> get props => [viewer];
 
-  late Viewer$Query$User viewer;
+@override Map<String, dynamic> toJson() => _$Viewer$QueryToJson(this);
 
-  @override
-  List<Object?> get props => [viewer];
-
-  @override
-  Map<String, dynamic> toJson() => _$Viewer$QueryToJson(this);
-}
-
+ }
 final VIEWER_QUERY_DOCUMENT_OPERATION_NAME = 'Viewer';
-final VIEWER_QUERY_DOCUMENT = DocumentNode(
-  definitions: [
-    OperationDefinitionNode(
-      type: OperationType.query,
-      name: NameNode(value: 'Viewer'),
-      variableDefinitions: [],
-      directives: [],
-      selectionSet: SelectionSetNode(
-        selections: [
-          FieldNode(
-            name: NameNode(value: 'viewer'),
-            alias: null,
-            arguments: [],
-            directives: [],
-            selectionSet: SelectionSetNode(
-              selections: [
-                FieldNode(
-                  name: NameNode(value: 'login'),
-                  alias: null,
-                  arguments: [],
-                  directives: [],
-                  selectionSet: null,
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  ],
-);
+final VIEWER_QUERY_DOCUMENT = 
+DocumentNode(definitions: [OperationDefinitionNode(type: OperationType.query, name: NameNode(value: 'Viewer'), variableDefinitions: [], directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: 'viewer'), alias: null, arguments: [], directives: [], selectionSet: SelectionSetNode(selections: [FieldNode(name: NameNode(value: 'login'), alias: null, arguments: [], directives: [], selectionSet: null, )]), )]), )])
+;class ViewerQuery extends GraphQLQuery<Viewer$Query, JsonSerializable> {ViewerQuery();
 
-class ViewerQuery extends GraphQLQuery<Viewer$Query, JsonSerializable> {
-  ViewerQuery();
+@override final DocumentNode document = VIEWER_QUERY_DOCUMENT;
 
-  @override
-  final DocumentNode document = VIEWER_QUERY_DOCUMENT;
+@override final String operationName = VIEWER_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  final String operationName = VIEWER_QUERY_DOCUMENT_OPERATION_NAME;
+@override List<Object?> get props => [document, operationName];
 
-  @override
-  List<Object?> get props => [document, operationName];
+@override Viewer$Query parse(Map<String, dynamic> json) => Viewer$Query.fromJson(json);
 
-  @override
-  Viewer$Query parse(Map<String, dynamic> json) => Viewer$Query.fromJson(json);
-}
+ }

--- a/packages/dartpollo/example/github/lib/__generated__/viewer.graphql.g.dart
+++ b/packages/dartpollo/example/github/lib/__generated__/viewer.graphql.g.dart
@@ -10,14 +10,10 @@ Viewer$Query$User _$Viewer$Query$UserFromJson(Map<String, dynamic> json) =>
     Viewer$Query$User()..login = json['login'] as String;
 
 Map<String, dynamic> _$Viewer$Query$UserToJson(Viewer$Query$User instance) =>
-    <String, dynamic>{
-      'login': instance.login,
-    };
+    <String, dynamic>{'login': instance.login};
 
 Viewer$Query _$Viewer$QueryFromJson(Map<String, dynamic> json) => Viewer$Query()
   ..viewer = Viewer$Query$User.fromJson(json['viewer'] as Map<String, dynamic>);
 
 Map<String, dynamic> _$Viewer$QueryToJson(Viewer$Query instance) =>
-    <String, dynamic>{
-      'viewer': instance.viewer.toJson(),
-    };
+    <String, dynamic>{'viewer': instance.viewer.toJson()};

--- a/packages/dartpollo/example/github/pubspec.lock
+++ b/packages/dartpollo/example/github/pubspec.lock
@@ -97,14 +97,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
-  cli_config:
-    dependency: transitive
-    description:
-      name: cli_config
-      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   code_builder:
     dependency: transitive
     description:
@@ -129,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  coverage:
-    dependency: transitive
-    description:
-      name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -159,7 +143,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0-alpha.1"
+    version: "0.1.0-alpha.2"
   dartpollo_annotation:
     dependency: transitive
     description:
@@ -223,14 +207,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -368,7 +344,7 @@ packages:
     source: hosted
     version: "6.13.0"
   lints:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: lints
       sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
@@ -407,14 +383,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  node_preamble:
-    dependency: transitive
-    description:
-      name: node_preamble
-      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -479,22 +447,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
-  shelf_packages_handler:
-    dependency: transitive
-    description:
-      name: shelf_packages_handler
-      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  shelf_static:
-    dependency: transitive
-    description:
-      name: shelf_static
-      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -519,22 +471,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.11"
-  source_map_stack_trace:
-    dependency: transitive
-    description:
-      name: source_map_stack_trace
-      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  source_maps:
-    dependency: transitive
-    description:
-      name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -583,14 +519,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  test:
-    dependency: "direct dev"
-    description:
-      name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
@@ -599,14 +527,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  test_core:
-    dependency: transitive
-    description:
-      name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -615,14 +535,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
-      url: "https://pub.dev"
-    source: hosted
-    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
@@ -655,14 +567,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   yaml:
     dependency: transitive
     description:

--- a/packages/dartpollo/example/github/pubspec.yaml
+++ b/packages/dartpollo/example/github/pubspec.yaml
@@ -15,5 +15,3 @@ dev_dependencies:
   dartpollo_generator:
     path: ../../../dartpollo_generator
   json_serializable:
-  lints: ^6.1.0
-  test:

--- a/packages/dartpollo/example/pokemon/lib/__generated__/big_query.graphql.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/big_query.graphql.dart
@@ -1,110 +1,79 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'big_query.graphql.g.dart';@JsonSerializable(explicitToJson: true) class BigQuery$Query$Charmander extends JsonSerializable with EquatableMixin {BigQuery$Query$Charmander();
 
-part 'big_query.graphql.g.dart';
+factory BigQuery$Query$Charmander.fromJson(Map<String, dynamic> json) => _$BigQuery$Query$CharmanderFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class BigQuery$Query$Charmander extends JsonSerializable with EquatableMixin {
-  BigQuery$Query$Charmander();
+String? number;
 
-  factory BigQuery$Query$Charmander.fromJson(Map<String, dynamic> json) =>
-      _$BigQuery$Query$CharmanderFromJson(json);
+List<String?>? types;
 
-  String? number;
+@override List<Object?> get props => [number, types];
 
-  List<String?>? types;
+@override Map<String, dynamic> toJson() => _$BigQuery$Query$CharmanderToJson(this);
 
-  @override
-  List<Object?> get props => [number, types];
+ }
+@JsonSerializable(explicitToJson: true) class BigQuery$Query$Pokemon$Evolutions extends JsonSerializable with EquatableMixin {BigQuery$Query$Pokemon$Evolutions();
 
-  @override
-  Map<String, dynamic> toJson() => _$BigQuery$Query$CharmanderToJson(this);
-}
+factory BigQuery$Query$Pokemon$Evolutions.fromJson(Map<String, dynamic> json) => _$BigQuery$Query$Pokemon$EvolutionsFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class BigQuery$Query$Pokemon$Evolutions extends JsonSerializable
-    with EquatableMixin {
-  BigQuery$Query$Pokemon$Evolutions();
+String? number;
 
-  factory BigQuery$Query$Pokemon$Evolutions.fromJson(
-    Map<String, dynamic> json,
-  ) => _$BigQuery$Query$Pokemon$EvolutionsFromJson(json);
+String? name;
 
-  String? number;
+@override List<Object?> get props => [number, name];
 
-  String? name;
+@override Map<String, dynamic> toJson() => _$BigQuery$Query$Pokemon$EvolutionsToJson(this);
 
-  @override
-  List<Object?> get props => [number, name];
+ }
+@JsonSerializable(explicitToJson: true) class BigQuery$Query$Pokemon extends JsonSerializable with EquatableMixin {BigQuery$Query$Pokemon();
 
-  @override
-  Map<String, dynamic> toJson() =>
-      _$BigQuery$Query$Pokemon$EvolutionsToJson(this);
-}
+factory BigQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) => _$BigQuery$Query$PokemonFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class BigQuery$Query$Pokemon extends JsonSerializable with EquatableMixin {
-  BigQuery$Query$Pokemon();
+String? number;
 
-  factory BigQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
-      _$BigQuery$Query$PokemonFromJson(json);
+String? name;
 
-  String? number;
+List<String?>? types;
 
-  String? name;
+List<BigQuery$Query$Pokemon$Evolutions?>? evolutions;
 
-  List<String?>? types;
+@override List<Object?> get props => [number, name, types, evolutions];
 
-  List<BigQuery$Query$Pokemon$Evolutions?>? evolutions;
+@override Map<String, dynamic> toJson() => _$BigQuery$Query$PokemonToJson(this);
 
-  @override
-  List<Object?> get props => [number, name, types, evolutions];
+ }
+@JsonSerializable(explicitToJson: true) class BigQuery$Query extends JsonSerializable with EquatableMixin {BigQuery$Query();
 
-  @override
-  Map<String, dynamic> toJson() => _$BigQuery$Query$PokemonToJson(this);
-}
+factory BigQuery$Query.fromJson(Map<String, dynamic> json) => _$BigQuery$QueryFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class BigQuery$Query extends JsonSerializable with EquatableMixin {
-  BigQuery$Query();
+BigQuery$Query$Charmander? charmander;
 
-  factory BigQuery$Query.fromJson(Map<String, dynamic> json) =>
-      _$BigQuery$QueryFromJson(json);
+List<BigQuery$Query$Pokemon?>? pokemons;
 
-  BigQuery$Query$Charmander? charmander;
+@override List<Object?> get props => [charmander, pokemons];
 
-  List<BigQuery$Query$Pokemon?>? pokemons;
+@override Map<String, dynamic> toJson() => _$BigQuery$QueryToJson(this);
 
-  @override
-  List<Object?> get props => [charmander, pokemons];
+ }
+@JsonSerializable(explicitToJson: true) class BigQueryArguments extends JsonSerializable with EquatableMixin {BigQueryArguments({required this.quantity});
 
-  @override
-  Map<String, dynamic> toJson() => _$BigQuery$QueryToJson(this);
-}
+@override factory BigQueryArguments.fromJson(Map<String, dynamic> json) => _$BigQueryArgumentsFromJson(json);
 
-@JsonSerializable(explicitToJson: true)
-class BigQueryArguments extends JsonSerializable with EquatableMixin {
-  BigQueryArguments({required this.quantity});
+late int quantity;
 
-  @override
-  factory BigQueryArguments.fromJson(Map<String, dynamic> json) =>
-      _$BigQueryArgumentsFromJson(json);
+@override List<Object?> get props => [quantity];
 
-  late int quantity;
+@override Map<String, dynamic> toJson() => _$BigQueryArgumentsToJson(this);
 
-  @override
-  List<Object?> get props => [quantity];
-
-  @override
-  Map<String, dynamic> toJson() => _$BigQueryArgumentsToJson(this);
-}
-
+ }
 final BIG_QUERY_QUERY_DOCUMENT_OPERATION_NAME = 'big_query';
-final BIG_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
+final BIG_QUERY_QUERY_DOCUMENT = 
+DocumentNodeHelpers.document([
   DocumentNodeHelpers.operation(
     OperationType.query,
     'big_query',
@@ -116,52 +85,33 @@ final BIG_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
       ),
     ],
     selections: [
-      DocumentNodeHelpers.field(
-        'pokemon',
-        alias: 'charmander',
-        args: {'name': 'Charmander'},
-        selections: [
-          DocumentNodeHelpers.field('number'),
-          DocumentNodeHelpers.field('types'),
-        ],
-      ),
-      DocumentNodeHelpers.field(
-        'pokemons',
-        args: {'first': DocumentNodeHelpers.variable('quantity')},
-        selections: [
+      DocumentNodeHelpers.field('pokemon', alias: 'charmander', args: {'name': 'Charmander'}, selections: [
+        DocumentNodeHelpers.field('number'),
+        DocumentNodeHelpers.field('types'),
+      ]),
+      DocumentNodeHelpers.field('pokemons', args: {'first': DocumentNodeHelpers.variable('quantity')}, selections: [
+        DocumentNodeHelpers.field('number'),
+        DocumentNodeHelpers.field('name'),
+        DocumentNodeHelpers.field('types'),
+        DocumentNodeHelpers.field('evolutions', alias: 'evolutions', selections: [
           DocumentNodeHelpers.field('number'),
           DocumentNodeHelpers.field('name'),
-          DocumentNodeHelpers.field('types'),
-          DocumentNodeHelpers.field(
-            'evolutions',
-            alias: 'evolutions',
-            selections: [
-              DocumentNodeHelpers.field('number'),
-              DocumentNodeHelpers.field('name'),
-            ],
-          ),
-        ],
-      ),
+        ]),
+      ]),
     ],
   ),
-]);
+])
 
-class BigQueryQuery extends GraphQLQuery<BigQuery$Query, BigQueryArguments> {
-  BigQueryQuery({required this.variables});
+;class BigQueryQuery extends GraphQLQuery<BigQuery$Query, BigQueryArguments> {BigQueryQuery({required this.variables});
 
-  @override
-  final DocumentNode document = BIG_QUERY_QUERY_DOCUMENT;
+@override final DocumentNode document = BIG_QUERY_QUERY_DOCUMENT;
 
-  @override
-  final String operationName = BIG_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
+@override final String operationName = BIG_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  final BigQueryArguments variables;
+@override final BigQueryArguments variables;
 
-  @override
-  List<Object?> get props => [document, operationName, variables];
+@override List<Object?> get props => [document, operationName, variables];
 
-  @override
-  BigQuery$Query parse(Map<String, dynamic> json) =>
-      BigQuery$Query.fromJson(json);
-}
+@override BigQuery$Query parse(Map<String, dynamic> json) => BigQuery$Query.fromJson(json);
+
+ }

--- a/packages/dartpollo/example/pokemon/lib/__generated__/big_query.graphql.g.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/big_query.graphql.g.dart
@@ -16,10 +16,7 @@ BigQuery$Query$Charmander _$BigQuery$Query$CharmanderFromJson(
 
 Map<String, dynamic> _$BigQuery$Query$CharmanderToJson(
   BigQuery$Query$Charmander instance,
-) => <String, dynamic>{
-  'number': instance.number,
-  'types': instance.types,
-};
+) => <String, dynamic>{'number': instance.number, 'types': instance.types};
 
 BigQuery$Query$Pokemon$Evolutions _$BigQuery$Query$Pokemon$EvolutionsFromJson(
   Map<String, dynamic> json,
@@ -29,10 +26,7 @@ BigQuery$Query$Pokemon$Evolutions _$BigQuery$Query$Pokemon$EvolutionsFromJson(
 
 Map<String, dynamic> _$BigQuery$Query$Pokemon$EvolutionsToJson(
   BigQuery$Query$Pokemon$Evolutions instance,
-) => <String, dynamic>{
-  'number': instance.number,
-  'name': instance.name,
-};
+) => <String, dynamic>{'number': instance.number, 'name': instance.name};
 
 BigQuery$Query$Pokemon _$BigQuery$Query$PokemonFromJson(
   Map<String, dynamic> json,
@@ -81,11 +75,7 @@ Map<String, dynamic> _$BigQuery$QueryToJson(BigQuery$Query instance) =>
     };
 
 BigQueryArguments _$BigQueryArgumentsFromJson(Map<String, dynamic> json) =>
-    BigQueryArguments(
-      quantity: (json['quantity'] as num).toInt(),
-    );
+    BigQueryArguments(quantity: (json['quantity'] as num).toInt());
 
 Map<String, dynamic> _$BigQueryArgumentsToJson(BigQueryArguments instance) =>
-    <String, dynamic>{
-      'quantity': instance.quantity,
-    };
+    <String, dynamic>{'quantity': instance.quantity};

--- a/packages/dartpollo/example/pokemon/lib/__generated__/fragment_query.graphql.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/fragment_query.graphql.dart
@@ -1,103 +1,69 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
-part 'fragment_query.graphql.g.dart';
-
-mixin PokemonPartsMixin {
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'fragment_query.graphql.g.dart';mixin PokemonPartsMixin {
   String? number;
-  String? name;
-  List<String?>? types;
-}
+String? name;
+List<String?>? types;
+}@JsonSerializable(explicitToJson: true) class FragmentQuery$Query$Charmander extends JsonSerializable with EquatableMixin,PokemonPartsMixin {FragmentQuery$Query$Charmander();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentQuery$Query$Charmander extends JsonSerializable
-    with EquatableMixin, PokemonPartsMixin {
-  FragmentQuery$Query$Charmander();
+factory FragmentQuery$Query$Charmander.fromJson(Map<String, dynamic> json) => _$FragmentQuery$Query$CharmanderFromJson(json);
 
-  factory FragmentQuery$Query$Charmander.fromJson(Map<String, dynamic> json) =>
-      _$FragmentQuery$Query$CharmanderFromJson(json);
+@override List<Object?> get props => [number, name, types];
 
-  @override
-  List<Object?> get props => [number, name, types];
+@override Map<String, dynamic> toJson() => _$FragmentQuery$Query$CharmanderToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentQuery$Query$CharmanderToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentQuery$Query$Pokemon$Evolutions extends JsonSerializable with EquatableMixin,PokemonPartsMixin {FragmentQuery$Query$Pokemon$Evolutions();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentQuery$Query$Pokemon$Evolutions extends JsonSerializable
-    with EquatableMixin, PokemonPartsMixin {
-  FragmentQuery$Query$Pokemon$Evolutions();
+factory FragmentQuery$Query$Pokemon$Evolutions.fromJson(Map<String, dynamic> json) => _$FragmentQuery$Query$Pokemon$EvolutionsFromJson(json);
 
-  factory FragmentQuery$Query$Pokemon$Evolutions.fromJson(
-    Map<String, dynamic> json,
-  ) => _$FragmentQuery$Query$Pokemon$EvolutionsFromJson(json);
+@override List<Object?> get props => [number, name, types];
 
-  @override
-  List<Object?> get props => [number, name, types];
+@override Map<String, dynamic> toJson() => _$FragmentQuery$Query$Pokemon$EvolutionsToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() =>
-      _$FragmentQuery$Query$Pokemon$EvolutionsToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentQuery$Query$Pokemon extends JsonSerializable with EquatableMixin,PokemonPartsMixin {FragmentQuery$Query$Pokemon();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentQuery$Query$Pokemon extends JsonSerializable
-    with EquatableMixin, PokemonPartsMixin {
-  FragmentQuery$Query$Pokemon();
+factory FragmentQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) => _$FragmentQuery$Query$PokemonFromJson(json);
 
-  factory FragmentQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
-      _$FragmentQuery$Query$PokemonFromJson(json);
+List<FragmentQuery$Query$Pokemon$Evolutions?>? evolutions;
 
-  List<FragmentQuery$Query$Pokemon$Evolutions?>? evolutions;
+@override List<Object?> get props => [number, name, types, evolutions];
 
-  @override
-  List<Object?> get props => [number, name, types, evolutions];
+@override Map<String, dynamic> toJson() => _$FragmentQuery$Query$PokemonToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentQuery$Query$PokemonToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentQuery$Query extends JsonSerializable with EquatableMixin {FragmentQuery$Query();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentQuery$Query extends JsonSerializable with EquatableMixin {
-  FragmentQuery$Query();
+factory FragmentQuery$Query.fromJson(Map<String, dynamic> json) => _$FragmentQuery$QueryFromJson(json);
 
-  factory FragmentQuery$Query.fromJson(Map<String, dynamic> json) =>
-      _$FragmentQuery$QueryFromJson(json);
+FragmentQuery$Query$Charmander? charmander;
 
-  FragmentQuery$Query$Charmander? charmander;
+List<FragmentQuery$Query$Pokemon?>? pokemons;
 
-  List<FragmentQuery$Query$Pokemon?>? pokemons;
+@override List<Object?> get props => [charmander, pokemons];
 
-  @override
-  List<Object?> get props => [charmander, pokemons];
+@override Map<String, dynamic> toJson() => _$FragmentQuery$QueryToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentQuery$QueryToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentQueryArguments extends JsonSerializable with EquatableMixin {FragmentQueryArguments({required this.quantity});
 
-@JsonSerializable(explicitToJson: true)
-class FragmentQueryArguments extends JsonSerializable with EquatableMixin {
-  FragmentQueryArguments({required this.quantity});
+@override factory FragmentQueryArguments.fromJson(Map<String, dynamic> json) => _$FragmentQueryArgumentsFromJson(json);
 
-  @override
-  factory FragmentQueryArguments.fromJson(Map<String, dynamic> json) =>
-      _$FragmentQueryArgumentsFromJson(json);
+late int quantity;
 
-  late int quantity;
+@override List<Object?> get props => [quantity];
 
-  @override
-  List<Object?> get props => [quantity];
+@override Map<String, dynamic> toJson() => _$FragmentQueryArgumentsToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentQueryArgumentsToJson(this);
-}
-
+ }
 final FRAGMENT_QUERY_QUERY_DOCUMENT_OPERATION_NAME = 'fragmentQuery';
-final FRAGMENT_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
+final FRAGMENT_QUERY_QUERY_DOCUMENT = 
+DocumentNodeHelpers.document([
   DocumentNodeHelpers.operation(
     OperationType.query,
     'fragmentQuery',
@@ -109,28 +75,15 @@ final FRAGMENT_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
       ),
     ],
     selections: [
-      DocumentNodeHelpers.field(
-        'pokemon',
-        alias: 'charmander',
-        args: {'name': 'Charmander'},
-        selections: [
+      DocumentNodeHelpers.field('pokemon', alias: 'charmander', args: {'name': 'Charmander'}, selections: [
+        DocumentNodeHelpers.fragmentSpread('PokemonParts'),
+      ]),
+      DocumentNodeHelpers.field('pokemons', args: {'first': DocumentNodeHelpers.variable('quantity')}, selections: [
+        DocumentNodeHelpers.fragmentSpread('PokemonParts'),
+        DocumentNodeHelpers.field('evolutions', alias: 'evolutions', selections: [
           DocumentNodeHelpers.fragmentSpread('PokemonParts'),
-        ],
-      ),
-      DocumentNodeHelpers.field(
-        'pokemons',
-        args: {'first': DocumentNodeHelpers.variable('quantity')},
-        selections: [
-          DocumentNodeHelpers.fragmentSpread('PokemonParts'),
-          DocumentNodeHelpers.field(
-            'evolutions',
-            alias: 'evolutions',
-            selections: [
-              DocumentNodeHelpers.fragmentSpread('PokemonParts'),
-            ],
-          ),
-        ],
-      ),
+        ]),
+      ]),
     ],
   ),
   DocumentNodeHelpers.fragmentDefinition(
@@ -142,25 +95,18 @@ final FRAGMENT_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
       DocumentNodeHelpers.field('types'),
     ],
   ),
-]);
+])
 
-class FragmentQueryQuery
-    extends GraphQLQuery<FragmentQuery$Query, FragmentQueryArguments> {
-  FragmentQueryQuery({required this.variables});
+;class FragmentQueryQuery extends GraphQLQuery<FragmentQuery$Query, FragmentQueryArguments> {FragmentQueryQuery({required this.variables});
 
-  @override
-  final DocumentNode document = FRAGMENT_QUERY_QUERY_DOCUMENT;
+@override final DocumentNode document = FRAGMENT_QUERY_QUERY_DOCUMENT;
 
-  @override
-  final String operationName = FRAGMENT_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
+@override final String operationName = FRAGMENT_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  final FragmentQueryArguments variables;
+@override final FragmentQueryArguments variables;
 
-  @override
-  List<Object?> get props => [document, operationName, variables];
+@override List<Object?> get props => [document, operationName, variables];
 
-  @override
-  FragmentQuery$Query parse(Map<String, dynamic> json) =>
-      FragmentQuery$Query.fromJson(json);
-}
+@override FragmentQuery$Query parse(Map<String, dynamic> json) => FragmentQuery$Query.fromJson(json);
+
+ }

--- a/packages/dartpollo/example/pokemon/lib/__generated__/fragment_query.graphql.g.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/fragment_query.graphql.g.dart
@@ -91,12 +91,8 @@ Map<String, dynamic> _$FragmentQuery$QueryToJson(
 
 FragmentQueryArguments _$FragmentQueryArgumentsFromJson(
   Map<String, dynamic> json,
-) => FragmentQueryArguments(
-  quantity: (json['quantity'] as num).toInt(),
-);
+) => FragmentQueryArguments(quantity: (json['quantity'] as num).toInt());
 
 Map<String, dynamic> _$FragmentQueryArgumentsToJson(
   FragmentQueryArguments instance,
-) => <String, dynamic>{
-  'quantity': instance.quantity,
-};
+) => <String, dynamic>{'quantity': instance.quantity};

--- a/packages/dartpollo/example/pokemon/lib/__generated__/fragments_glob.graphql.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/fragments_glob.graphql.dart
@@ -1,140 +1,90 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
-part 'fragments_glob.graphql.g.dart';
-
-mixin PokemonMixin {
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'fragments_glob.graphql.g.dart';mixin PokemonMixin {
   late String id;
-  PokemonMixin$PokemonDimension? weight;
-  PokemonMixin$PokemonAttack? attacks;
-}
-mixin WeightMixin {
+PokemonMixin$PokemonDimension? weight;
+PokemonMixin$PokemonAttack? attacks;
+}mixin WeightMixin {
   String? minimum;
-}
-mixin PokemonAttackMixin {
+}mixin PokemonAttackMixin {
   List<PokemonAttackMixin$Attack?>? special;
-}
-mixin AttackMixin {
+}mixin AttackMixin {
   String? name;
-}
+}@JsonSerializable(explicitToJson: true) class FragmentsGlob$Query$Pokemon$Pokemon extends JsonSerializable with EquatableMixin,PokemonMixin {FragmentsGlob$Query$Pokemon$Pokemon();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentsGlob$Query$Pokemon$Pokemon extends JsonSerializable
-    with EquatableMixin, PokemonMixin {
-  FragmentsGlob$Query$Pokemon$Pokemon();
+factory FragmentsGlob$Query$Pokemon$Pokemon.fromJson(Map<String, dynamic> json) => _$FragmentsGlob$Query$Pokemon$PokemonFromJson(json);
 
-  factory FragmentsGlob$Query$Pokemon$Pokemon.fromJson(
-    Map<String, dynamic> json,
-  ) => _$FragmentsGlob$Query$Pokemon$PokemonFromJson(json);
+@override List<Object?> get props => [id, weight, attacks];
 
-  @override
-  List<Object?> get props => [id, weight, attacks];
+@override Map<String, dynamic> toJson() => _$FragmentsGlob$Query$Pokemon$PokemonToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() =>
-      _$FragmentsGlob$Query$Pokemon$PokemonToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentsGlob$Query$Pokemon extends JsonSerializable with EquatableMixin,PokemonMixin {FragmentsGlob$Query$Pokemon();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentsGlob$Query$Pokemon extends JsonSerializable
-    with EquatableMixin, PokemonMixin {
-  FragmentsGlob$Query$Pokemon();
+factory FragmentsGlob$Query$Pokemon.fromJson(Map<String, dynamic> json) => _$FragmentsGlob$Query$PokemonFromJson(json);
 
-  factory FragmentsGlob$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
-      _$FragmentsGlob$Query$PokemonFromJson(json);
+List<FragmentsGlob$Query$Pokemon$Pokemon?>? evolutions;
 
-  List<FragmentsGlob$Query$Pokemon$Pokemon?>? evolutions;
+@override List<Object?> get props => [id, weight, attacks, evolutions];
 
-  @override
-  List<Object?> get props => [id, weight, attacks, evolutions];
+@override Map<String, dynamic> toJson() => _$FragmentsGlob$Query$PokemonToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentsGlob$Query$PokemonToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class FragmentsGlob$Query extends JsonSerializable with EquatableMixin {FragmentsGlob$Query();
 
-@JsonSerializable(explicitToJson: true)
-class FragmentsGlob$Query extends JsonSerializable with EquatableMixin {
-  FragmentsGlob$Query();
+factory FragmentsGlob$Query.fromJson(Map<String, dynamic> json) => _$FragmentsGlob$QueryFromJson(json);
 
-  factory FragmentsGlob$Query.fromJson(Map<String, dynamic> json) =>
-      _$FragmentsGlob$QueryFromJson(json);
+FragmentsGlob$Query$Pokemon? pokemon;
 
-  FragmentsGlob$Query$Pokemon? pokemon;
+@override List<Object?> get props => [pokemon];
 
-  @override
-  List<Object?> get props => [pokemon];
+@override Map<String, dynamic> toJson() => _$FragmentsGlob$QueryToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$FragmentsGlob$QueryToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class PokemonMixin$PokemonDimension extends JsonSerializable with EquatableMixin,WeightMixin {PokemonMixin$PokemonDimension();
 
-@JsonSerializable(explicitToJson: true)
-class PokemonMixin$PokemonDimension extends JsonSerializable
-    with EquatableMixin, WeightMixin {
-  PokemonMixin$PokemonDimension();
+factory PokemonMixin$PokemonDimension.fromJson(Map<String, dynamic> json) => _$PokemonMixin$PokemonDimensionFromJson(json);
 
-  factory PokemonMixin$PokemonDimension.fromJson(Map<String, dynamic> json) =>
-      _$PokemonMixin$PokemonDimensionFromJson(json);
+@override List<Object?> get props => [minimum];
 
-  @override
-  List<Object?> get props => [minimum];
+@override Map<String, dynamic> toJson() => _$PokemonMixin$PokemonDimensionToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$PokemonMixin$PokemonDimensionToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class PokemonMixin$PokemonAttack extends JsonSerializable with EquatableMixin,PokemonAttackMixin {PokemonMixin$PokemonAttack();
 
-@JsonSerializable(explicitToJson: true)
-class PokemonMixin$PokemonAttack extends JsonSerializable
-    with EquatableMixin, PokemonAttackMixin {
-  PokemonMixin$PokemonAttack();
+factory PokemonMixin$PokemonAttack.fromJson(Map<String, dynamic> json) => _$PokemonMixin$PokemonAttackFromJson(json);
 
-  factory PokemonMixin$PokemonAttack.fromJson(Map<String, dynamic> json) =>
-      _$PokemonMixin$PokemonAttackFromJson(json);
+@override List<Object?> get props => [special];
 
-  @override
-  List<Object?> get props => [special];
+@override Map<String, dynamic> toJson() => _$PokemonMixin$PokemonAttackToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$PokemonMixin$PokemonAttackToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class PokemonAttackMixin$Attack extends JsonSerializable with EquatableMixin,AttackMixin {PokemonAttackMixin$Attack();
 
-@JsonSerializable(explicitToJson: true)
-class PokemonAttackMixin$Attack extends JsonSerializable
-    with EquatableMixin, AttackMixin {
-  PokemonAttackMixin$Attack();
+factory PokemonAttackMixin$Attack.fromJson(Map<String, dynamic> json) => _$PokemonAttackMixin$AttackFromJson(json);
 
-  factory PokemonAttackMixin$Attack.fromJson(Map<String, dynamic> json) =>
-      _$PokemonAttackMixin$AttackFromJson(json);
+@override List<Object?> get props => [name];
 
-  @override
-  List<Object?> get props => [name];
+@override Map<String, dynamic> toJson() => _$PokemonAttackMixin$AttackToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$PokemonAttackMixin$AttackToJson(this);
-}
-
+ }
 final FRAGMENTS_GLOB_QUERY_DOCUMENT_OPERATION_NAME = 'fragments_glob';
-final FRAGMENTS_GLOB_QUERY_DOCUMENT = DocumentNodeHelpers.document([
+final FRAGMENTS_GLOB_QUERY_DOCUMENT = 
+DocumentNodeHelpers.document([
   DocumentNodeHelpers.operation(
     OperationType.query,
     '',
     selections: [
-      DocumentNodeHelpers.field(
-        'pokemon',
-        args: {'name': 'Pikachu'},
-        selections: [
+      DocumentNodeHelpers.field('pokemon', args: {'name': 'Pikachu'}, selections: [
+        DocumentNodeHelpers.fragmentSpread('Pokemon'),
+        DocumentNodeHelpers.field('evolutions', selections: [
           DocumentNodeHelpers.fragmentSpread('Pokemon'),
-          DocumentNodeHelpers.field(
-            'evolutions',
-            selections: [
-              DocumentNodeHelpers.fragmentSpread('Pokemon'),
-            ],
-          ),
-        ],
-      ),
+        ]),
+      ]),
     ],
   ),
   DocumentNodeHelpers.fragmentDefinition(
@@ -142,18 +92,12 @@ final FRAGMENTS_GLOB_QUERY_DOCUMENT = DocumentNodeHelpers.document([
     'Pokemon',
     selections: [
       DocumentNodeHelpers.field('id'),
-      DocumentNodeHelpers.field(
-        'weight',
-        selections: [
-          DocumentNodeHelpers.fragmentSpread('weight'),
-        ],
-      ),
-      DocumentNodeHelpers.field(
-        'attacks',
-        selections: [
-          DocumentNodeHelpers.fragmentSpread('pokemonAttack'),
-        ],
-      ),
+      DocumentNodeHelpers.field('weight', selections: [
+        DocumentNodeHelpers.fragmentSpread('weight'),
+      ]),
+      DocumentNodeHelpers.field('attacks', selections: [
+        DocumentNodeHelpers.fragmentSpread('pokemonAttack'),
+      ]),
     ],
   ),
   DocumentNodeHelpers.fragmentDefinition(
@@ -167,12 +111,9 @@ final FRAGMENTS_GLOB_QUERY_DOCUMENT = DocumentNodeHelpers.document([
     'pokemonAttack',
     'PokemonAttack',
     selections: [
-      DocumentNodeHelpers.field(
-        'special',
-        selections: [
-          DocumentNodeHelpers.fragmentSpread('attack'),
-        ],
-      ),
+      DocumentNodeHelpers.field('special', selections: [
+        DocumentNodeHelpers.fragmentSpread('attack'),
+      ]),
     ],
   ),
   DocumentNodeHelpers.fragmentDefinition(
@@ -182,22 +123,16 @@ final FRAGMENTS_GLOB_QUERY_DOCUMENT = DocumentNodeHelpers.document([
       DocumentNodeHelpers.field('name'),
     ],
   ),
-]);
+])
 
-class FragmentsGlobQuery
-    extends GraphQLQuery<FragmentsGlob$Query, JsonSerializable> {
-  FragmentsGlobQuery();
+;class FragmentsGlobQuery extends GraphQLQuery<FragmentsGlob$Query, JsonSerializable> {FragmentsGlobQuery();
 
-  @override
-  final DocumentNode document = FRAGMENTS_GLOB_QUERY_DOCUMENT;
+@override final DocumentNode document = FRAGMENTS_GLOB_QUERY_DOCUMENT;
 
-  @override
-  final String operationName = FRAGMENTS_GLOB_QUERY_DOCUMENT_OPERATION_NAME;
+@override final String operationName = FRAGMENTS_GLOB_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  List<Object?> get props => [document, operationName];
+@override List<Object?> get props => [document, operationName];
 
-  @override
-  FragmentsGlob$Query parse(Map<String, dynamic> json) =>
-      FragmentsGlob$Query.fromJson(json);
-}
+@override FragmentsGlob$Query parse(Map<String, dynamic> json) => FragmentsGlob$Query.fromJson(json);
+
+ }

--- a/packages/dartpollo/example/pokemon/lib/__generated__/fragments_glob.graphql.g.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/fragments_glob.graphql.g.dart
@@ -72,9 +72,7 @@ FragmentsGlob$Query _$FragmentsGlob$QueryFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentsGlob$QueryToJson(
   FragmentsGlob$Query instance,
-) => <String, dynamic>{
-  'pokemon': instance.pokemon?.toJson(),
-};
+) => <String, dynamic>{'pokemon': instance.pokemon?.toJson()};
 
 PokemonMixin$PokemonDimension _$PokemonMixin$PokemonDimensionFromJson(
   Map<String, dynamic> json,
@@ -82,9 +80,7 @@ PokemonMixin$PokemonDimension _$PokemonMixin$PokemonDimensionFromJson(
 
 Map<String, dynamic> _$PokemonMixin$PokemonDimensionToJson(
   PokemonMixin$PokemonDimension instance,
-) => <String, dynamic>{
-  'minimum': instance.minimum,
-};
+) => <String, dynamic>{'minimum': instance.minimum};
 
 PokemonMixin$PokemonAttack _$PokemonMixin$PokemonAttackFromJson(
   Map<String, dynamic> json,
@@ -109,6 +105,4 @@ PokemonAttackMixin$Attack _$PokemonAttackMixin$AttackFromJson(
 
 Map<String, dynamic> _$PokemonAttackMixin$AttackToJson(
   PokemonAttackMixin$Attack instance,
-) => <String, dynamic>{
-  'name': instance.name,
-};
+) => <String, dynamic>{'name': instance.name};

--- a/packages/dartpollo/example/pokemon/lib/__generated__/simple_query.graphql.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/simple_query.graphql.dart
@@ -1,77 +1,56 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
-import 'package:dartpollo/dartpollo.dart';
-import 'package:equatable/equatable.dart';
-import 'package:gql/ast.dart';
-import 'package:json_annotation/json_annotation.dart';
-part 'simple_query.graphql.g.dart';
+// dart format off
+import 'package:dartpollo/dartpollo.dart';import 'package:equatable/equatable.dart';import 'package:gql/ast.dart';import 'package:json_annotation/json_annotation.dart';part 'simple_query.graphql.g.dart';@JsonSerializable(explicitToJson: true) class SimpleQuery$Query$Pokemon extends JsonSerializable with EquatableMixin {SimpleQuery$Query$Pokemon();
 
-@JsonSerializable(explicitToJson: true)
-class SimpleQuery$Query$Pokemon extends JsonSerializable with EquatableMixin {
-  SimpleQuery$Query$Pokemon();
+factory SimpleQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) => _$SimpleQuery$Query$PokemonFromJson(json);
 
-  factory SimpleQuery$Query$Pokemon.fromJson(Map<String, dynamic> json) =>
-      _$SimpleQuery$Query$PokemonFromJson(json);
+String? number;
 
-  String? number;
+List<String?>? types;
 
-  List<String?>? types;
+@override List<Object?> get props => [number, types];
 
-  @override
-  List<Object?> get props => [number, types];
+@override Map<String, dynamic> toJson() => _$SimpleQuery$Query$PokemonToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$SimpleQuery$Query$PokemonToJson(this);
-}
+ }
+@JsonSerializable(explicitToJson: true) class SimpleQuery$Query extends JsonSerializable with EquatableMixin {SimpleQuery$Query();
 
-@JsonSerializable(explicitToJson: true)
-class SimpleQuery$Query extends JsonSerializable with EquatableMixin {
-  SimpleQuery$Query();
+factory SimpleQuery$Query.fromJson(Map<String, dynamic> json) => _$SimpleQuery$QueryFromJson(json);
 
-  factory SimpleQuery$Query.fromJson(Map<String, dynamic> json) =>
-      _$SimpleQuery$QueryFromJson(json);
+SimpleQuery$Query$Pokemon? pokemon;
 
-  SimpleQuery$Query$Pokemon? pokemon;
+@override List<Object?> get props => [pokemon];
 
-  @override
-  List<Object?> get props => [pokemon];
+@override Map<String, dynamic> toJson() => _$SimpleQuery$QueryToJson(this);
 
-  @override
-  Map<String, dynamic> toJson() => _$SimpleQuery$QueryToJson(this);
-}
-
+ }
 final SIMPLE_QUERY_QUERY_DOCUMENT_OPERATION_NAME = 'simple_query';
-final SIMPLE_QUERY_QUERY_DOCUMENT = DocumentNodeHelpers.document([
+final SIMPLE_QUERY_QUERY_DOCUMENT = 
+DocumentNodeHelpers.document([
   DocumentNodeHelpers.operation(
     OperationType.query,
     'simple_query',
     selections: [
-      DocumentNodeHelpers.field(
-        'pokemon',
-        args: {'name': 'Charmander'},
-        selections: [
-          DocumentNodeHelpers.field('number'),
-          DocumentNodeHelpers.field('types'),
-        ],
-      ),
+      DocumentNodeHelpers.field('pokemon', args: {'name': 'Charmander'}, selections: [
+        DocumentNodeHelpers.field('number'),
+        DocumentNodeHelpers.field('types'),
+      ]),
     ],
   ),
-]);
+])
 
-class SimpleQueryQuery
-    extends GraphQLQuery<SimpleQuery$Query, JsonSerializable> {
-  SimpleQueryQuery();
+;class SimpleQueryQuery extends GraphQLQuery<SimpleQuery$Query, JsonSerializable> {SimpleQueryQuery();
 
-  @override
-  final DocumentNode document = SIMPLE_QUERY_QUERY_DOCUMENT;
+@override final DocumentNode document = SIMPLE_QUERY_QUERY_DOCUMENT;
 
-  @override
-  final String operationName = SIMPLE_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
+@override final String operationName = SIMPLE_QUERY_QUERY_DOCUMENT_OPERATION_NAME;
 
-  @override
-  List<Object?> get props => [document, operationName];
+@override List<Object?> get props => [document, operationName];
 
-  @override
-  SimpleQuery$Query parse(Map<String, dynamic> json) =>
-      SimpleQuery$Query.fromJson(json);
-}
+@override SimpleQuery$Query parse(Map<String, dynamic> json) => SimpleQuery$Query.fromJson(json);
+
+ }

--- a/packages/dartpollo/example/pokemon/lib/__generated__/simple_query.graphql.g.dart
+++ b/packages/dartpollo/example/pokemon/lib/__generated__/simple_query.graphql.g.dart
@@ -16,10 +16,7 @@ SimpleQuery$Query$Pokemon _$SimpleQuery$Query$PokemonFromJson(
 
 Map<String, dynamic> _$SimpleQuery$Query$PokemonToJson(
   SimpleQuery$Query$Pokemon instance,
-) => <String, dynamic>{
-  'number': instance.number,
-  'types': instance.types,
-};
+) => <String, dynamic>{'number': instance.number, 'types': instance.types};
 
 SimpleQuery$Query _$SimpleQuery$QueryFromJson(Map<String, dynamic> json) =>
     SimpleQuery$Query()
@@ -30,6 +27,4 @@ SimpleQuery$Query _$SimpleQuery$QueryFromJson(Map<String, dynamic> json) =>
             );
 
 Map<String, dynamic> _$SimpleQuery$QueryToJson(SimpleQuery$Query instance) =>
-    <String, dynamic>{
-      'pokemon': instance.pokemon?.toJson(),
-    };
+    <String, dynamic>{'pokemon': instance.pokemon?.toJson()};

--- a/packages/dartpollo/example/pokemon/pubspec.lock
+++ b/packages/dartpollo/example/pokemon/pubspec.lock
@@ -97,14 +97,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
-  cli_config:
-    dependency: transitive
-    description:
-      name: cli_config
-      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.0"
   code_builder:
     dependency: transitive
     description:
@@ -129,14 +121,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  coverage:
-    dependency: transitive
-    description:
-      name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -159,7 +143,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.1.0-alpha.1"
+    version: "0.1.0-alpha.2"
   dartpollo_annotation:
     dependency: transitive
     description:
@@ -176,7 +160,7 @@ packages:
     source: path
     version: "0.1.0-alpha.1"
   dio:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: dio
       sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
@@ -223,14 +207,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -368,7 +344,7 @@ packages:
     source: hosted
     version: "6.13.0"
   lints:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: lints
       sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
@@ -407,14 +383,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  node_preamble:
-    dependency: transitive
-    description:
-      name: node_preamble
-      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -479,22 +447,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
-  shelf_packages_handler:
-    dependency: transitive
-    description:
-      name: shelf_packages_handler
-      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  shelf_static:
-    dependency: transitive
-    description:
-      name: shelf_static
-      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -519,22 +471,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.11"
-  source_map_stack_trace:
-    dependency: transitive
-    description:
-      name: source_map_stack_trace
-      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  source_maps:
-    dependency: transitive
-    description:
-      name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -583,14 +519,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  test:
-    dependency: "direct dev"
-    description:
-      name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
@@ -599,14 +527,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  test_core:
-    dependency: transitive
-    description:
-      name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -615,14 +535,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
-      url: "https://pub.dev"
-    source: hosted
-    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
@@ -655,14 +567,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   yaml:
     dependency: transitive
     description:

--- a/packages/dartpollo/example/pokemon/pubspec.yaml
+++ b/packages/dartpollo/example/pokemon/pubspec.yaml
@@ -8,12 +8,9 @@ environment:
 dependencies:
   dartpollo:
     path: ../../
-  dio:
 
 dev_dependencies:
   build_runner:
   dartpollo_generator:
     path: ../../../dartpollo_generator
   json_serializable:
-  lints: ^6.1.0
-  test:

--- a/packages/dartpollo/pubspec.yaml
+++ b/packages/dartpollo/pubspec.yaml
@@ -29,6 +29,5 @@ dependencies:
   json_annotation: ^4.11.0
 
 dev_dependencies:
-  lints: ^6.1.0
   pedantic_mono: ^1.34.0
   test: ^1.31.0

--- a/packages/dartpollo_annotation/pubspec.yaml
+++ b/packages/dartpollo_annotation/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   gql: ^1.0.1
   gql_exec: ^1.1.1-alpha+1699813812660
   json_annotation: ^4.11.0
-  pedantic_mono: ^1.34.0
   yaml: ^3.1.3
 
 dev_dependencies:
+  pedantic_mono: ^1.34.0
   test: ^1.31.0

--- a/packages/dartpollo_generator/lib/generator/print_helpers.dart
+++ b/packages/dartpollo_generator/lib/generator/print_helpers.dart
@@ -5,6 +5,7 @@ import 'package:dartpollo_generator/generator/data/data.dart';
 import 'package:dartpollo_generator/generator/data/enum_value_definition.dart';
 import 'package:dartpollo_generator/generator/errors.dart';
 import 'package:gql/ast.dart';
+
 // ignore: implementation_imports
 import 'package:gql_code_builder/src/ast.dart' as dart;
 import 'package:recase/recase.dart';
@@ -735,13 +736,22 @@ String specToString(Spec spec) {
 
 /// Generate Dart code typings from a query or mutation and its response from
 /// a [QueryDefinition] into a buffer.
+///
+/// The output is intentionally emitted as-is (no `dart_style` post-processing)
+/// so that the generated file looks like a plain, freezed-style generated
+/// artifact. Consumers should rely on the header comments below to skip lints
+/// and coverage for the file rather than on a specific whitespace layout.
 void writeLibraryDefinitionToBuffer(
   StringBuffer buffer,
   List<String> ignoreForFile,
   LibraryDefinition definition,
   GeneratorOptions options,
 ) {
-  buffer.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND');
+  buffer
+    ..writeln('// GENERATED CODE - DO NOT MODIFY BY HAND')
+    ..writeln('// coverage:ignore-file')
+    ..writeln('// ignore_for_file: type=lint')
+    ..writeln('// ignore_for_file: $_defaultIgnoreForFile');
   if (ignoreForFile.isNotEmpty) {
     buffer.writeln(
       '// ignore_for_file: ${Set<String>.from(ignoreForFile).join(', ')}',
@@ -749,12 +759,24 @@ void writeLibraryDefinitionToBuffer(
   }
   buffer
     ..write('\n')
+    ..writeln('// dart format off')
     ..write(specToString(generateLibrarySpec(definition, options)));
 }
+
+/// The default set of analyzer/lint rules ignored in every generated file.
+///
+/// Mirrors what freezed-generated files emit, so the produced code does not
+/// surface lints or skew coverage reports for consumers.
+const String _defaultIgnoreForFile =
+    'unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark';
 
 /// Generate an empty file just exporting the library. This is used to avoid
 /// a breaking change on file generation.
 String writeLibraryForwarder(LibraryDefinition definition) =>
     '''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: $_defaultIgnoreForFile
+// dart format off
 export '${definition.basename}.dart';
 ''';

--- a/packages/dartpollo_generator/pubspec.yaml
+++ b/packages/dartpollo_generator/pubspec.yaml
@@ -18,7 +18,6 @@ resolution: workspace
 
 dependencies:
   build: ^4.0.5
-  build_config: ^1.3.0
   code_builder: ^4.11.1
   collection: ^1.19.1
   crypto: ^3.0.7
@@ -29,20 +28,13 @@ dependencies:
   gql: ^1.0.1
   gql_code_builder: ^0.15.1
   json_annotation: ^4.11.0
-  meta: ^1.18.2
   path: ^1.9.1
   pub_semver: ^2.2.0
   recase: ^4.1.0
   source_gen: ^4.2.2
-  yaml: ^3.1.3
 
 dev_dependencies:
-  args: ^2.7.0
-  build_runner: ^2.13.1
   build_test: ^3.5.12
-  json_serializable: ^6.13.0
-  lints: ^6.0.0
   logging: ^1.3.0
-  mocktail: ^1.0.4
   pedantic_mono: ^1.34.0
   test: ^1.31.0

--- a/packages/dartpollo_generator/test/generator/print_helpers_test.dart
+++ b/packages/dartpollo_generator/test/generator/print_helpers_test.dart
@@ -1118,28 +1118,31 @@ part 'test_query.graphql.g.dart';
       );
     });
 
-    test('makes dart format a no-op on writeLibraryDefinitionToBuffer output',
-        () {
-      final buffer = StringBuffer();
-      writeLibraryDefinitionToBuffer(
-        buffer,
-        const <String>[],
-        LibraryDefinition(basename: r'test_query.graphql'),
-        GeneratorOptions(),
-      );
+    test(
+      'makes dart format a no-op on writeLibraryDefinitionToBuffer output',
+      () {
+        final buffer = StringBuffer();
+        writeLibraryDefinitionToBuffer(
+          buffer,
+          const <String>[],
+          LibraryDefinition(basename: r'test_query.graphql'),
+          GeneratorOptions(),
+        );
 
-      final output = buffer.toString();
-      final formatted = DartFormatter(
-        languageVersion: DartFormatter.latestLanguageVersion,
-      ).format(output);
+        final output = buffer.toString();
+        final formatted = DartFormatter(
+          languageVersion: DartFormatter.latestLanguageVersion,
+        ).format(output);
 
-      expect(
-        formatted,
-        equals(output),
-        reason: 'Running `dart format` on generated output must produce no '
-            'changes (the `// dart format off` marker opts the body out).',
-      );
-    });
+        expect(
+          formatted,
+          equals(output),
+          reason:
+              'Running `dart format` on generated output must produce no '
+              'changes (the `// dart format off` marker opts the body out).',
+        );
+      },
+    );
 
     test('makes dart format a no-op on writeLibraryForwarder output', () {
       final output = writeLibraryForwarder(
@@ -1153,7 +1156,8 @@ part 'test_query.graphql.g.dart';
       expect(
         formatted,
         equals(output),
-        reason: 'Running `dart format` on the forwarder must produce no '
+        reason:
+            'Running `dart format` on the forwarder must produce no '
             'changes (the `// dart format off` marker opts the body out).',
       );
     });

--- a/packages/dartpollo_generator/test/generator/print_helpers_test.dart
+++ b/packages/dartpollo_generator/test/generator/print_helpers_test.dart
@@ -9,14 +9,23 @@ import 'package:test/test.dart';
 /// Normalizes Dart code by formatting it with dart_style.
 /// This makes tests resilient to whitespace/formatting differences
 /// from code_builder's DartEmitter output.
+///
+/// The `// dart format off` / `// dart format on` marker comments — which the
+/// generator emits so consumers' `dart format` runs leave generated files
+/// untouched — are stripped before formatting so the formatter can still
+/// normalize whitespace differences between the hand-written expected
+/// strings and code_builder's emitter output.
 String _normalizeCode(String code) {
+  final stripped = code
+      .replaceAll('// dart format off\n', '')
+      .replaceAll('// dart format on\n', '');
   try {
     return DartFormatter(
       languageVersion: DartFormatter.latestLanguageVersion,
-    ).format(code);
+    ).format(stripped);
   } on FormatterException catch (_) {
     // If formatting fails (e.g. partial code), normalize whitespace manually
-    return code
+    return stripped
         .split('\n')
         .map((l) => l.trimRight())
         .join('\n')
@@ -580,6 +589,9 @@ class AClass extends JsonSerializable with EquatableMixin {
       expect(
         buffer.toString(),
         equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -607,6 +619,9 @@ part 'test_query.graphql.g.dart';
       expect(
         buffer.toString(),
         equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -643,6 +658,9 @@ part 'test_query.graphql.g.dart';
       expect(
         buffer.toString(),
         equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:dartpollo/dartpollo.dart';
 import 'package:equatable/equatable.dart';
@@ -707,6 +725,9 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, JsonSerializable> {
         expect(
           buffer.toString(),
           equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -759,6 +780,9 @@ final TEST_QUERY_QUERY_DOCUMENT = DocumentNode(definitions: [
       expect(
         buffer.toString(),
         equalsFormattedCode(r'''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:dartpollo/dartpollo.dart';
 import 'package:equatable/equatable.dart';
@@ -945,6 +969,9 @@ class TestQueryQuery extends GraphQLQuery<TestQuery, TestQueryArguments> {
       expect(
         buffer.toString(),
         equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -988,6 +1015,9 @@ enum SomeEnum {
     expect(
       buffer.toString(),
       equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -1012,6 +1042,9 @@ part 'test_query.graphql.g.dart';
     expect(
       buffer.toString(),
       equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 import 'package:equatable/equatable.dart';
 import 'package:gql/ast.dart';
@@ -1038,6 +1071,9 @@ part 'test_query.graphql.g.dart';
       expect(
         buffer.toString(),
         equalsFormattedCode('''// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 // ignore_for_file: my_rule_1, my_rule_2
 
 import 'package:equatable/equatable.dart';
@@ -1048,4 +1084,78 @@ part 'test_query.graphql.g.dart';
       );
     },
   );
+
+  group('// dart format off marker', () {
+    test('is emitted by writeLibraryDefinitionToBuffer', () {
+      final buffer = StringBuffer();
+      writeLibraryDefinitionToBuffer(
+        buffer,
+        const <String>[],
+        LibraryDefinition(basename: r'test_query.graphql'),
+        GeneratorOptions(),
+      );
+
+      expect(
+        buffer.toString(),
+        contains('// dart format off'),
+        reason:
+            'Generated files must opt out of dart_style so consumers running '
+            '`dart format` see no changes (mirroring freezed behaviour).',
+      );
+    });
+
+    test('is emitted by writeLibraryForwarder', () {
+      final output = writeLibraryForwarder(
+        LibraryDefinition(basename: r'test_query.graphql'),
+      );
+
+      expect(
+        output,
+        contains('// dart format off'),
+        reason:
+            'Forwarder files must opt out of dart_style so `dart format` is a '
+            'no-op on them.',
+      );
+    });
+
+    test('makes dart format a no-op on writeLibraryDefinitionToBuffer output',
+        () {
+      final buffer = StringBuffer();
+      writeLibraryDefinitionToBuffer(
+        buffer,
+        const <String>[],
+        LibraryDefinition(basename: r'test_query.graphql'),
+        GeneratorOptions(),
+      );
+
+      final output = buffer.toString();
+      final formatted = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
+      ).format(output);
+
+      expect(
+        formatted,
+        equals(output),
+        reason: 'Running `dart format` on generated output must produce no '
+            'changes (the `// dart format off` marker opts the body out).',
+      );
+    });
+
+    test('makes dart format a no-op on writeLibraryForwarder output', () {
+      final output = writeLibraryForwarder(
+        LibraryDefinition(basename: r'test_query.graphql'),
+      );
+
+      final formatted = DartFormatter(
+        languageVersion: DartFormatter.latestLanguageVersion,
+      ).format(output);
+
+      expect(
+        formatted,
+        equals(output),
+        reason: 'Running `dart format` on the forwarder must produce no '
+            'changes (the `// dart format off` marker opts the body out).',
+      );
+    });
+  });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,4 +23,4 @@ melos:
       exec:
         concurrency: 1
     format:
-      run: dart format .
+      run: dart format packages/


### PR DESCRIPTION
## Summary

Two separate concerns, one PR (two commits):

### 1. `feat(generator): emit freezed-style headers + dart format off`

Generated files now carry the same opt-out comments freezed emits, so consumers' tooling leaves them alone:

```
// GENERATED CODE - DO NOT MODIFY BY HAND
// coverage:ignore-file
// ignore_for_file: type=lint
// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
// dart format off
```

- `// coverage:ignore-file` → coverage tools skip generated files.
- `// ignore_for_file: type=lint` + freezed lint list → no lint noise from generated code.
- `// dart format off` (introduced in `dart_style` 2.3.7, shipped in Dart SDK 3.7+) → `dart format` is a no-op on the file body, matching freezed's behaviour. Output stays "plain" (no `DartFormatter` step in the generator).

Files: `packages/dartpollo_generator/lib/generator/print_helpers.dart`, `packages/dartpollo_generator/test/generator/print_helpers_test.dart`, and the regenerated `example/{github,pokemon}/lib/__generated__/*.dart`.

### 2. `chore(deps): drop unused dependencies across workspace`

Every pubspec was audited; entries were removed only when there was no `package:` import in source/tests and no reference from `analysis_options.yaml`.

- `packages/dartpollo_generator/pubspec.yaml`: dropped `build_config`, `yaml` (deps) and `args`, `build_runner`, `json_serializable`, `lints`, `mocktail` (dev_deps).
- `packages/dartpollo/pubspec.yaml`: dropped `lints` (dev_dep); kept `pedantic_mono` (referenced by `analysis_options.yaml`).
- `packages/dartpollo_annotation/pubspec.yaml`: moved `pedantic_mono` from `dependencies` to `dev_dependencies` (it's only used by `analysis_options.yaml`, not at runtime).
- `packages/dartpollo/example/github/pubspec.yaml`: dropped `lints` and `test` (no `test/` dir, no imports).
- `packages/dartpollo/example/pokemon/pubspec.yaml`: dropped `dio`, `lints`, `test`.
- `build_runner` and `json_serializable` are kept in each example because `dartpollo_generator`'s `build.yaml` chains the `json_serializable|json_serializable` builder.

## Verification

- `fvm dart test test/generator/print_helpers_test.dart` — **31/31 passed** (27 existing + 4 new `// dart format off` marker tests asserting `DartFormatter.format(output) == output`).
- `fvm dart test` in `dartpollo_generator` — **490/490 passed**.
- `fvm dart test` in `dartpollo` — **132/132 passed**.
- `fvm dart test` in `dartpollo_annotation` — **1/1 passed**.
- `fvm dart analyze` on all packages — `No issues found!`.
- `fvm dart pub get` at the workspace root and in each example app — resolved cleanly after the cleanup.

## Notes

- The `// dart format off` marker only takes effect for consumers on Dart SDK 3.7+ (or 3.6 with the `tall-style` experiment). Older SDKs would still see reformatting — same constraint freezed has.