### PR TITLE
chore: bump all packages to 0.1.0-alpha.3 and update CHANGELOGs

### DIFF
--- a/packages/dartpollo/CHANGELOG.md
+++ b/packages/dartpollo/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.0-alpha.3
+
+- Dropped unused workspace dependencies from `pubspec.yaml`
+- Bumped `dartpollo_annotation` constraint to `^0.1.0-alpha.3`
+- Updated example projects (GitHub, Pokémon) to consume the latest generator output (Freezed-style headers, `// dart format off`)
+
 ## 0.1.0-alpha.2
 
 - Migrated HTTP layer from `gql_http_link` / `http` to `gql_dio_link` / `dio` for both `DartpolloClient` and `DartpolloCachedClient`

--- a/packages/dartpollo/pubspec.yaml
+++ b/packages/dartpollo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo
-version: 0.1.0-alpha.2
+version: 0.1.0-alpha.3
 
 description: A Dart GraphQL client with caching support. Build dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo
@@ -18,7 +18,7 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.6
-  dartpollo_annotation: ^0.1.0-alpha.1
+  dartpollo_annotation: ^0.1.0-alpha.3
   dio: ^5.9.2
   gql: ^1.0.1
   gql_dedupe_link: ^4.0.0

--- a/packages/dartpollo_annotation/CHANGELOG.md
+++ b/packages/dartpollo_annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0-alpha.3
+
+- Dropped unused workspace dependencies from `pubspec.yaml`
+- Aligned package version with `dartpollo` and `dartpollo_generator` (skipped `alpha.2`)
+
 ## 0.1.0-alpha.1
 
 - Initial release as standalone package

--- a/packages/dartpollo_annotation/pubspec.yaml
+++ b/packages/dartpollo_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_annotation
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.3
 
 description: Shared types and annotations for the dartpollo GraphQL client and generator.
 repository: https://github.com/dwikyhardi/dartpollo

--- a/packages/dartpollo_generator/CHANGELOG.md
+++ b/packages/dartpollo_generator/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.0-alpha.3
+
+- Emit Freezed-style headers in generated code: `// coverage:ignore-file`, `// ignore_for_file: type=lint` with the freezed lint list, so consumers don't see lints or coverage hits on generated files
+- Append `// dart format off` (dart_style 2.3.7+) to generated files so `dart format` becomes a no-op on generator output (matches `freezed`)
+- Dropped unused workspace dependencies from `pubspec.yaml`
+- Bumped `dartpollo_annotation` constraint to `^0.1.0-alpha.3`
+- Reformatted `print_helpers_test` for consistent readability; scoped `dart format` script to `packages/`
+- Aligned package version with `dartpollo` and `dartpollo_annotation` (skipped `alpha.2`)
+
 ## 0.1.0-alpha.1
 
 - Initial release as standalone package

--- a/packages/dartpollo_generator/pubspec.yaml
+++ b/packages/dartpollo_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_generator
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.3
 
 description: Code generator for the dartpollo GraphQL client. Builds Dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo
@@ -22,7 +22,7 @@ dependencies:
   collection: ^1.19.1
   crypto: ^3.0.7
   dart_style: ^3.1.3
-  dartpollo_annotation: ^0.1.0-alpha.1
+  dartpollo_annotation: ^0.1.0-alpha.3
   equatable: ^2.0.8
   glob: ^2.1.3
   gql: ^1.0.1


### PR DESCRIPTION
## Summary

Align all three workspace packages at `0.1.0-alpha.3` and refresh their respective `CHANGELOG.md` entries.

## Version changes

| Package | Before | After |
| --- | --- | --- |
| `dartpollo` | `0.1.0-alpha.2` | `0.1.0-alpha.3` |
| `dartpollo_annotation` | `0.1.0-alpha.1` | `0.1.0-alpha.3` |
| `dartpollo_generator` | `0.1.0-alpha.1` | `0.1.0-alpha.3` |

Cross-package dependency constraints in `dartpollo` and `dartpollo_generator` on `dartpollo_annotation` were bumped to `^0.1.0-alpha.3` to match.

## CHANGELOG highlights

- **dartpollo**: dropped unused workspace deps; bumped annotation constraint; example projects updated to consume Freezed-style generator output.
- **dartpollo_annotation**: dropped unused workspace deps; version aligned with siblings (`alpha.2` skipped intentionally).
- **dartpollo_generator**: Freezed-style headers (`// coverage:ignore-file`, `// ignore_for_file: type=lint` with the freezed lint list) + `// dart format off` in generated output; workspace deps cleanup; `print_helpers_test` reformatting; `dart format` script scoped to `packages/`; annotation constraint bumped.

## Verification

- `dart pub get` at workspace root resolves cleanly with the new versions.

---

Co-authored-by: Junie <junie@jetbrains.com>