### PR TITLE
fix(generator): loosen gql_code_builder constraint to ^0.13.4

### DIFF
--- a/packages/dartpollo/pubspec.yaml
+++ b/packages/dartpollo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo
-version: 0.1.0-alpha.4
+version: 0.1.0-alpha.5
 
 description: A Dart GraphQL client with caching support. Build dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo

--- a/packages/dartpollo_annotation/pubspec.yaml
+++ b/packages/dartpollo_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_annotation
-version: 0.1.0-alpha.4
+version: 0.1.0-alpha.5
 
 description: Shared types and annotations for the dartpollo GraphQL client and generator.
 repository: https://github.com/dwikyhardi/dartpollo

--- a/packages/dartpollo_generator/pubspec.yaml
+++ b/packages/dartpollo_generator/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   equatable: ^2.0.8
   glob: ^2.1.3
   gql: ^1.0.1
-  gql_code_builder: 0.13.4
+  gql_code_builder: ^0.13.4
   json_annotation: ^4.12.0
   path: ^1.9.1
   pub_semver: ^2.2.0

--- a/packages/dartpollo_generator/pubspec.yaml
+++ b/packages/dartpollo_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_generator
-version: 0.1.0-alpha.4
+version: 0.1.0-alpha.5
 
 description: Code generator for the dartpollo GraphQL client. Builds Dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo


### PR DESCRIPTION
## Summary

Loosens `dartpollo_generator`'s `gql_code_builder` dependency from the pinned `0.13.4` to the compatible range `^0.13.4`.

## Why

`dart pub publish --dry-run` for `dartpollo_generator` reported a validation warning:

> Your dependency on "gql_code_builder" should allow more than one version.

Pinning to a single version makes the package hard to use alongside other packages that also depend on `gql_code_builder`. Using `^0.13.4` clears the warning while still resolving to `0.13.4` today.

## Verification

- `dart pub get` resolves cleanly (still selects `0.13.4`).
- `dart pub publish --dry-run` no longer reports the `gql_code_builder` single-version warning.