### PR TITLE
chore: bump all packages to 0.1.0-alpha.6

### DIFF
--- a/packages/dartpollo/CHANGELOG.md
+++ b/packages/dartpollo/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-alpha.6
+
+- Version bump to keep the monorepo packages aligned (no functional changes)
+
 ## 0.1.0-alpha.4
 
 - Raised minimum Dart SDK constraint to `^3.10.0`

--- a/packages/dartpollo/pubspec.yaml
+++ b/packages/dartpollo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo
-version: 0.1.0-alpha.5
+version: 0.1.0-alpha.6
 
 description: A Dart GraphQL client with caching support. Build dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo

--- a/packages/dartpollo_annotation/CHANGELOG.md
+++ b/packages/dartpollo_annotation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-alpha.6
+
+- Version bump to keep the monorepo packages aligned (no functional changes)
+
 ## 0.1.0-alpha.4
 
 - Raised minimum Dart SDK constraint to `^3.10.0`

--- a/packages/dartpollo_annotation/pubspec.yaml
+++ b/packages/dartpollo_annotation/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_annotation
-version: 0.1.0-alpha.5
+version: 0.1.0-alpha.6
 
 description: Shared types and annotations for the dartpollo GraphQL client and generator.
 repository: https://github.com/dwikyhardi/dartpollo

--- a/packages/dartpollo_generator/CHANGELOG.md
+++ b/packages/dartpollo_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-alpha.6
+
+- Loosened `gql_code_builder` constraint to `^0.13.4` (was pinned to `0.13.4`) so it can be used alongside other packages depending on `gql_code_builder`
+
 ## 0.1.0-alpha.4
 
 - Raised minimum Dart SDK constraint to `^3.10.0`

--- a/packages/dartpollo_generator/pubspec.yaml
+++ b/packages/dartpollo_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartpollo_generator
-version: 0.1.0-alpha.5
+version: 0.1.0-alpha.6
 
 description: Code generator for the dartpollo GraphQL client. Builds Dart types from GraphQL schemas and queries.
 repository: https://github.com/dwikyhardi/dartpollo


### PR DESCRIPTION
## Summary

Bumps all three monorepo packages from `0.1.0-alpha.5` to `0.1.0-alpha.6` and updates their CHANGELOGs.

## Changes

- `dartpollo`, `dartpollo_annotation`, `dartpollo_generator`: `version` -> `0.1.0-alpha.6`.
- CHANGELOGs:
  - `dartpollo` / `dartpollo_annotation`: aligned version bump (no functional changes).
  - `dartpollo_generator`: documents the loosened `gql_code_builder: ^0.13.4` constraint.

## Verification

- `dart pub publish --dry-run` passes for all three packages (only the expected "uncommitted files" warning during the local run; the generator's prior `gql_code_builder` single-version warning is gone).

## Notes

- Branched from updated `main` (`530650d`). Merging this to `main` triggers `auto-tag.yml` -> `*-v0.1.0-alpha.6` tags -> OIDC publish workflows.
